### PR TITLE
Initial support for bot process to persist between turns

### DIFF
--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -624,15 +624,18 @@ class Connection {
     }; /* }}} */
     disconnectFromGame(game_id) { /* {{{ */
         if (DEBUG) {
-            conn_log("Disconnected from game", game_id);
+            conn_log("disconnectFromGame", game_id);
         }
         if (game_id in this.connected_games) {
             clearTimeout(this.connected_game_timeouts[game_id])
             this.connected_games[game_id].disconnect();
+            if (this.connected_games[game_id].bot) {
+                this.connected_games[game_id].bot.kill();
+                this.connected_games[game_id].bot = null;
+            }
+            delete this.connected_games[game_id];
+            delete this.connected_game_timeouts[game_id];
         }
-
-        delete this.connected_games[game_id];
-        delete this.connected_game_timeouts[game_id];
     }; /* }}} */
     deleteNotification(notification) { /* {{{ */
         this.socket.emit('notification/delete', this.auth({notification_id: notification.id}), (x) => {

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -522,7 +522,7 @@ class Game {
             if (!this.connected) return;
             this.log("gamedata");
 
-            this.log("Gamedata:", JSON.stringify(gamedata, null, 4));
+            //this.log("Gamedata:", JSON.stringify(gamedata, null, 4));
             this.state = gamedata;
             this.my_color = this.conn.bot_id == this.state.players.black.id ? "black" : "white";
 

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -306,7 +306,6 @@ class Game {
                 if (this.waiting_on_gamedata_to_make_move && this.state.moves.length == this.move_number_were_waiting_for) {
                     this.makeMove(this.move_number_were_waiting_for);
                     this.waiting_on_gamedata_to_make_move = false;
-                    this.move_number_were_waiting_for += 2;
                 }
             }
             else if (this.state.phase == 'finished') {
@@ -381,6 +380,7 @@ class Game {
         if (this.state.phase != 'play') {
             return;
         }
+        this.move_number_were_waiting_for = move_number + 2;
 
         ++moves_processing;
 

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -890,10 +890,6 @@ class Connection {
         return obj;
     } /* }}} */
     connectToGame(game_id) { /* {{{ */
-        if (DEBUG) {
-            conn_log("Connecting to game", game_id);
-        }
-
         if (argv.timeout)
         {
             if (game_id in this.connected_games) {

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -306,7 +306,7 @@ class Game {
                 if (this.waiting_on_gamedata_to_make_move && this.state.moves.length == this.move_number_were_waiting_for) {
                     this.makeMove(this.move_number_were_waiting_for);
                     this.waiting_on_gamedata_to_make_move = false;
-                    this.move_number_were_waiting_for = -1;
+                    this.move_number_were_waiting_for += 2;
                 }
             }
             else if (this.state.phase == 'finished') {

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -534,7 +534,6 @@ class Game {
                 this.bot.loadClock(this.state);
             }
         });
->>>>>>> 867a841a66d2320fd3775a5921f2e5ee4e3fd50e
         this.socket.on('game/' + game_id + '/phase', (phase) => {
             if (!this.connected) return;
             this.log("phase", phase)

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -86,6 +86,7 @@ if (argv.debug) {
 
 if (argv.persist) {
     PERSIST = true;
+}
 
 // TODO: Test known_commands for kgs-time_settings to set this, and remove the command line option
 if (argv.kgstime) {

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -516,6 +516,18 @@ class Game {
 
             //this.log("Gamedata:", JSON.stringify(gamedata, null, 4));
             this.state = gamedata;
+
+            // If server has issues it might send us a new gamedata packet and not a move event. We could try to
+            // check if we're missing a move and send it to bot out of gamadata. For now as a safe fallback just
+            // restart the bot by killing it here if another gamedata comes in. There normally should only be one
+            // before we process any moves, and makeMove() is where a new Bot is created.
+            //
+            if (this.bot) {
+                this.log("Killing bot because of gamedata packet after bot was started");
+                this.bot.kill();
+                this.bot = null;
+            }
+
             check_for_move();
 
             this.my_color = this.conn.bot_id == this.state.players.black.id ? "black" : "white";

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -577,6 +577,9 @@ class Connection {
             if (gamedata.phase == "play" && gamedata.player_to_move == this.bot_id) {
                 this.processMove(gamedata);
             }
+            // When a game ends, we don't get a "finished" active_game.phase. Probably since the game is no
+            // longer active.
+            //
             if (gamedata.phase == "finished") {
                 this.disconnectFromGame(gamedata.id);
             } else {

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -354,7 +354,6 @@ class Game {
 
         let passed = false;
         let passAndRestart = () => {
-            printf("pass and restart called");
             if (!passed) {
                 passed = true;
                 this.log("Bot process crashed, state was");

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -311,6 +311,9 @@ class Game {
             }
             else if (this.state.phase == 'finished') {
                 this.log("Game is finished");
+                if (DEBUG) this.log("Killing bot process");
+                this.bot.kill();
+                this.bot = null;
             }
         }
 
@@ -393,6 +396,7 @@ class Game {
                 }));
                 --moves_processing;
                 this.bot.kill();
+                this.bot = null;
             }
         }
 
@@ -436,7 +440,7 @@ class Game {
         return this.conn.auth(obj);
     }; /* }}} */
     disconnect() { /* {{{ */
-        this.log("Disconnecting");
+        this.log("Disconnecting from game #", this.game_id);
 
         this.connected = false;
         this.socket.emit('game/disconnect', this.auth({
@@ -544,7 +548,7 @@ class Connection {
         });
         socket.on('disconnect', () => {
             this.connected = false;
-            conn_log("Disconnected");
+            conn_log("Disconnected from server");
             for (let game_id in this.connected_games) {
                 this.disconnectFromGame(game_id);
             }
@@ -586,7 +590,7 @@ class Connection {
                 if (this.connected_game_timeouts[gamedata.id]) {
                     clearTimeout(this.connected_game_timeouts[gamedata.id])
                 }
-                conn_log("Setting timeout for", gamedata.id);
+                if (DEBUG) conn_log("Setting timeout for", gamedata.id);
                 this.connected_game_timeouts[gamedata.id] = setTimeout(() => {
                     this.disconnectFromGame(gamedata.id);
                 }, argv.timeout); /* forget about game after --timeout seconds */

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -443,7 +443,7 @@ class Bot {
 
         //this.command("genmove " + (this.last_color == 'black' ? 'white' : 'black'), 
         this.command("genmove " + this.game.my_color,
-             (move) => {
+            (move) => {
                 move = typeof(move) == "string" ? move.toLowerCase() : null;
                 let resign = move == 'resign';
                 let pass = move == 'pass';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtp2ogs",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "Wrapper to allow Gnu Go Text Protocol speaking Go engines to connect to Online-Go.com and play games",
   "main": "gtp2ogs.js",
   "files": [ "gtp2ogs.js" ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtp2ogs",
-  "version": "5.0.5",
+  "version": "5.0.7",
   "description": "Wrapper to allow Gnu Go Text Protocol speaking Go engines to connect to Online-Go.com and play games",
   "main": "gtp2ogs.js",
   "files": [ "gtp2ogs.js" ],


### PR DESCRIPTION
Here's the start towards optional persistent bot process. It worked in my testing pretty well with Leela. Two issues for further thought are:

1. Should .disconnect() kill the bot process? Are there ever times we .disconnect() and still want the bot to keep working? Clearly if the game has finished we can disconnect and kill the process. Currently only disconnect.
2. After bot passes, the bot is called to genmove a second time in a row. Maybe something to do with the pass and restart crash test, need to examine that further.

I'm doing the pull request so you can look over the diff and provide any feedback you might have as I keep working on it?