### PR TITLE
Calculate clocks before genmove, not when we get a clock event

### DIFF
--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -356,7 +356,7 @@ class Bot {
         this.game.my_color = this.conn.bot_id == state.players.black.id ? "black" : "white";
         //this.log(state);
 
-        this.loadClock(state);
+        //this.loadClock(state);
 
         if (state.initial_state) {
             let black = decodeMoves(state.initial_state.black, state.width);
@@ -433,6 +433,11 @@ class Bot {
         // Only relevent with persistent bots. Leave the setting on until we actually have requested a move.
         //
         this.firstmove = false;
+
+        // Do this here so we only do it once, plus if there is a long delay between clock message and move message, we'll
+        // subtract that missing time from what we tell the bot.
+        //
+        this.loadClock(state);
 
         this.command("genmove " + this.game.my_color,
             (move) => {
@@ -512,12 +517,7 @@ class Game {
                 this.makeMove(this.state.moves.length);
             }
         });
-        // TODO: I seem to get this event consistantly later than states are loaded. Calling loadClock below ends up being after 
-        // genmove is already called, so the bot doesn't have accurate clock info before doing genmove. Unsure how to fix this.
-        //
-        // TODO: Update clock information each time we get it, but only send it immediately before a genmove instead of each time.
-        // Bot only needs updated clock info right before a genmove, and extra communcation would interfere with Leela pondering.
-        //
+
         this.socket.on('game/' + game_id + '/clock', (clock) => {
             if (!this.connected) return;
             if (DEBUG) this.log("clock");
@@ -525,9 +525,10 @@ class Game {
             //this.log("Clock: ", JSON.stringify(clock));
             this.state.clock = clock;
 
-            if (this.bot) {
-                this.bot.loadClock(this.state);
-            }
+            // Bot only needs updated clock info right before a genmove, and extra communcation would interfere with Leela pondering.
+            //if (this.bot) {
+            //    this.bot.loadClock(this.state);
+            //}
         });
         this.socket.on('game/' + game_id + '/phase', (phase) => {
             if (!this.connected) return;


### PR DESCRIPTION
Sometimes there is a long delay between the clock message and the move message. This time gets "lost" and the bot doesn't know about it, which can lead to a timeout. By calculating the loadClock() right before a genmove, which calls now() at that time instead of when the clock packet arrived, the lost time is subtracted from the bot's available time left.

This should be a huge improvement on reducing bot timeouts?