### PR TITLE
Check for missing state before setting clock or phase

### DIFF
--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -639,7 +639,11 @@ class Game {
             if (DEBUG) this.log("clock");
 
             //this.log("Clock: ", JSON.stringify(clock));
-            this.state.clock = clock;
+            if (this.state) {
+                this.state.clock = clock;
+            } else {
+                if (DEBUG) console.error("Received clock for " + this.game_id + "but no state exists");
+            }
 
             // Bot only needs updated clock info right before a genmove, and extra communcation would interfere with Leela pondering.
             //if (this.bot) {
@@ -651,7 +655,12 @@ class Game {
             this.log("phase", phase)
 
             //this.log("Move: ", move);
-            this.state.phase = phase;
+            if (this.state) {
+                this.state.phase = phase;
+            } else {
+                if (DEBUG) console.error("Received phase for " + this.game_id + "but no state exists");
+            }
+
             if (phase == 'play') {
                 /* FIXME: This is pretty stupid.. we know what state we're in to
                  * see if it's our move or not, but it's late and blindly sending

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -239,7 +239,7 @@ class Bot {
                 }
             }
 
-            if (stdout_buffer[stdout_buffer.length-1] != '\n') {
+            if (!stdout_buffer || stdout_buffer[stdout_buffer.length-1] != '\n') {
                 //this.log("Partial result received, buffering until the output ends with a newline");
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtp2ogs",
-  "version": "5.1.0-beta.2",
+  "version": "5.1.0",
   "description": "Wrapper to allow Gnu Go Text Protocol speaking Go engines to connect to Online-Go.com and play games",
   "main": "gtp2ogs.js",
   "files": [ "gtp2ogs.js" ],


### PR DESCRIPTION
Tokumoto had a crash here, perhaps because he was using --timeout. I've not tested --timeout in ages.

If we get a clock for a missing state do we need to disconnect and delete the game object? Maybe the clock game in before initial game state somehow?