### PR TITLE
Add --hidden flag to not list the bot in the main computer drop down

### DIFF
--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -112,6 +112,7 @@ let optimist = require("optimist")
     .describe('nopause', 'Do not allow games to be paused')
     .describe('nopauseranked', 'Do not allow ranked games to be paused')
     .describe('nopauseunranked', 'Do not allow unranked games to be paused')
+    .describe('hidden', 'Don\'t list the bot in the public challenge list')
 ;
 let argv = optimist.argv;
 
@@ -1026,8 +1027,8 @@ class Connection {
                 socket.emit('notification/connect', this.auth({}), (x) => {
                     conn_log(x);
                 })
-                socket.emit('bot/connect', this.auth({ }), () => {
-                })
+                socket.emit('bot/connect', this.auth({ }));
+                socket.emit('bot/hidden', !!argv.hidden);
             });
         });
 


### PR DESCRIPTION
Implements #29

This capability is currently available on the beta server, I'll merge once it's available in production.

This flag can be set and and cleared whenever the bot operator wants by sending `socket.emit('bot/hidden', true);` or `socket.emit('bot/hidden', false);`

So could in theory be used to hide / unhide the bot from the main challenge list depending on whatever criteria the operator wants (such as unlisting the bot when there's a game in progress). However that is left as an exercise to the reader, this patch just provide a coarse command line option.