### PR TITLE
Tutorial + reworked readme + minhandicap + komi

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,37 +9,45 @@ with [OGS (Online-Go.com Server)](https://online-go.com/)
 
 # Installation
 
-  1. Use your systems package manager or otherwise install `node.js` from http://nodejs.org/
+#### 1. Use your systems package manager or otherwise install `node.js` from http://nodejs.org/ 
+  
+(this will also install npm = node package manager)
 
-  2. Run
-    ```
-    npm install gtp2ogs
-    ```
-If npm install gives you an error, try doing the above commands with ```sudo npm install -g gtp2ogs``` instead.
+#### 2. Run
 
-  3. Optionally install any missing node.js packages if basic usage below fails, such as:
-    ```
-    npm install socket.io-client
-    npm install optimist
-    npm install tracer
-    ```
+For linux in terminal, or for windows in a node.js command prompt (as admin) :
+
+```
+npm install gtp2ogs
+```
+If npm install gives you an error, try doing the above commands with `npm install -g gtp2ogs` instead (add `sudo` for linux, run as admin for windows).
+
+On all operating systems, gtp2ogs will be installed in 2 different directories, but the one that needs to be run with node is gtp2ogs.js in node_modules directory
+
+#### 3. Optionally install any missing node.js packages if basic usage below fails, such as:
+  
+```
+npm install socket.io-client
+npm install optimist
+npm install tracer
+  ```
 
 # Basic usage
 
-for linux (preferably as sudo) :
+For linux (preferably as sudo) :
 
 ```
 node /path/to/node_modules/gtp2ogs/gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- path/to/your/ai/runfile.file <bot argument1> <bot argument2>
 ```
 
-for windows (preferably as admin) : 
+For windows (preferably as admin) : 
 
 ```
 pushd C:\Program Files\nodejs && node.exe C:\path\to\node_modules\gtp2ogs\gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- C:\Users\path\to\your\ai\executable.exe <bot arguments>
 ```
 
 note : for all operating systemps, in ` -- `, the spaces after <gtp2ogsarguments> and before path/to/your/bot.executable are important : they separate gtp2ogs arguments from your bot arguments
-
+  
 note 2 : to play on [beta OGS server](https://beta.online-go.com/) instead of the [OGS server](https://online-go.com/), add the `-- beta` argument
 
 # Optional : To upgrade to devel branch
@@ -57,12 +65,11 @@ If your bot engine does not support all komi values, it is likely that some game
 
 For example [PhoenixGo](https://github.com/Tencent/PhoenixGo) only supports a komi of 7.5, and any other komi value chosen will crash the bot (including the widespread 6.5 and 0.5 komi)
 
-There is no `--komi` gtp2ogs argument yet, that would reject games that do not have the wanted komi, however there is a workaround of editing gtp2ogs.js so that it will tell your engine that the komi wil always be the set value (for example 7.5).
+There is no `--komi` gtp2ogs argument yet (that would reject games that do not have the wanted komi), however there is the  workaround of editing gtp2ogs.js so that it will tell your engine that the komi wil always be the set value (for example 7.5), even if it's not true on the OGS game.
 
 This method will result in some uncorrect scoring (so do not use it for ranked games), but at least your engine will be able to play
 
-for more details, see : 
-
+For more details, see : 
 - for linux : [3A4) Optional : Edit the gtp2ogs.js file (for example force komi to 7.5)](3A4-linux-optional-edit-gtp2ogs-js-file.md)
 - for windows : [3B4) Optional : Modify the gtp2ogs.js file (for example force komi to 7.5)](/docs/3B4-windows-optional-edit-gtp2ogs-js-file.md)
 

--- a/README.md
+++ b/README.md
@@ -73,20 +73,6 @@ To upgrade to devel branch, see :
 - for linux : [3A3) Optional : Upgrade gtp2ogs.js from old branch to “devel” branch (latest)](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3A3-linux-optional-upgrade-to-devel.md)
 - for windows : [3B3) Optional : Upgrade gtp2ogs from old branch to devel (latest) branch](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3B3-windows-optional-upgrade-to-devel.md)
 
-# Optional : workaround for komi not supported by your engine
-
-If your bot engine does not support all komi values, it is likely that some games will fail to start.
-
-For example, [PhoenixGo](https://github.com/Tencent/PhoenixGo) only supports a komi of 7.5, and any other komi value chosen will crash the bot (including the widespread 6.5 and 0.5 komi)
-
-There is no `--komi` gtp2ogs argument yet (that would reject games that do not have the wanted komi), however there is a   workaround : you can edit gtp2ogs.js file so that it will always tell your engine the komi is the set value (for example 7.5), even if it's not true in the OGS game.
-
-This method will result in some uncorrect scoring (so do not use it for ranked games), but at least your engine will be able to play.
-
-For more details, see : 
-- for linux : [3A4) Optional : Edit the gtp2ogs.js file (for example force komi to 7.5)](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3A4-linux-optional-edit-gtp2ogs-js-file.md)
-- for windows : [3B4) Optional : Modify the gtp2ogs.js file (for example force komi to 7.5)](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3B4-windows-optional-edit-gtp2ogs-js-file.md)
-
 # Options
 
 The following options are placed in the above ```<arguments>``` section.  Put a space in between options when there are more than one.  Also put a space in between the option and the parameter like:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
-gtp2ogs
-=======
+# gtp2ogs
 
 This script allows Go bots that support GTP (Go Text Protocol) to communicate
-with OGS (Online-Go.com Server)
+with [OGS (Online-Go.com Server)](https://online-go.com/)
 
-Installation
-============
+# Full tutorial 
+
+[for linux and windows, with screenshots, examples, and detailed explanations](https://github.com/wonderingabout/gtp2ogs-tutorial)
+
+# Installation
 
   1. Use your systems package manager or otherwise install `node.js` from http://nodejs.org/
+
   2. Run
     ```
     npm install gtp2ogs
     ```
+If npm install gives you an error, try doing the above commands with ```sudo npm install -g gtp2ogs``` instead.
+
   3. Optionally install any missing node.js packages if basic usage below fails, such as:
     ```
     npm install socket.io-client
@@ -19,20 +24,54 @@ Installation
     npm install tracer
     ```
 
-If npm install gives you an error, try doing the above commands with ```npm install -g``` instead.
+# Basic usage
 
-Basic usage
-===========
+for linux (preferably as sudo) :
 
 ```
-gtp2ogs --botid <id> --apikey <apikey> <arguments> -- <bot command> <bot arguments>
+node /path/to/node_modules/gtp2ogs/gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- path/to/your/ai/runfile.file <bot argument1> <bot argument2>
 ```
- The space in front of ```<bot command>``` is important
 
-Options
-=======
+for windows (preferably as admin) : 
+
+```
+pushd C:\Program Files\nodejs && node.exe C:\path\to\node_modules\gtp2ogs\gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- C:\Users\path\to\your\ai\executable.exe <bot arguments>
+```
+
+note : for all operating systemps, in ` -- `, the spaces after <gtp2ogsarguments> and before path/to/your/bot.executable are important : they separate gtp2ogs arguments from your bot arguments
+
+note 2 : to play on [beta OGS server](https://beta.online-go.com/) instead of the [OGS server](https://online-go.com/), add the `-- beta` argument
+
+# Optional : To upgrade to devel branch
+
+By default, npm installs an old release that does not include latest improvements and fixes
+
+To upgrade to devel branch, see :
+
+- for linux : [3A3) Optional : Upgrade gtp2ogs.js from old branch to “devel” branch (latest)](/docs/3A3-linux-optional-upgrade-to-devel.md)
+- for windows : [3B3) Optional : Upgrade gtp2ogs from old branch to devel (latest) branch](/docs/3B3-windows-optional-upgrade-to-devel.md)
+
+# Optional : workaround for komi not supported by your engine
+
+If your bot engine does not support all komi values, it is likely that some games will fail to start and be played
+
+For example [PhoenixGo](https://github.com/Tencent/PhoenixGo) only supports a komi of 7.5, and any other komi value chosen will crash the bot (including the widespread 6.5 and 0.5 komi)
+
+There is no `--komi` gtp2ogs argument yet, that would reject games that do not have the wanted komi, however there is a workaround of editing gtp2ogs.js so that it will tell your engine that the komi wil always be the set value (for example 7.5).
+
+This method will result in some uncorrect scoring (so do not use it for ranked games), but at least your engine will be able to play
+
+for more details, see : 
+
+- for linux : [3A4) Optional : Edit the gtp2ogs.js file (for example force komi to 7.5)](3A4-linux-optional-edit-gtp2ogs-js-file.md)
+- for windows : [3B4) Optional : Modify the gtp2ogs.js file (for example force komi to 7.5)](/docs/3B4-windows-optional-edit-gtp2ogs-js-file.md)
+
+# Options
+
 The following options are placed in the above ```<arguments>``` section.  Put a space in between options when there are more than one.  Also put a space in between the option and the parameter like:
-```--startupbuffer 2 --boardsize 13,19 --ban UserX,playerY ```
+
+```
+--startupbuffer 2 --boardsize 13,19 --ban UserX,playerY ```
 
   ```--host```  OGS Host to connect to (default online-go.com)
 
@@ -42,7 +81,7 @@ The following options are placed in the above ```<arguments>``` section.  Put a 
 
   ```--insecure```  Don't use ssl to connect to the ggs/rest servers
 
-  ```--beta```  Connect to the beta server (sets ggs/rest hosts to the beta server)
+  ```--beta```  Connect to the [beta server](https://beta.online-go.com/) instead of [OGS](https://online-go.com/) (sets ggs/rest hosts to the beta server)
 
   ```--debug, -d```  Output GTP command and responses from your Go engine
 
@@ -94,6 +133,8 @@ The following options are placed in the above ```<arguments>``` section.  Put a 
 
   ```--maxperiodsunranked```  Maximum number of unranked periods
 
+  ```--maxactivegames``` Maximum number of active games per player
+
   ```--minrank```  Minimum opponent rank to accept (e.g. 15k)
 
   ```--maxrank```  Maximum opponent rank to accept (e.g. 1d)
@@ -121,4 +162,6 @@ The following options are placed in the above ```<arguments>``` section.  Put a 
   ```--nopauseunranked```  Do not allow unranked games to be paused
 
   ```--hidden```  Hides the botname from the OGS game creation bot list
+
+note : a list of gtp2ogs arguments is also available [here](https://github.com/online-go/gtp2ogs/blob/devel/gtp2ogs.js) (ctrl+f "describe")
 

--- a/README.md
+++ b/README.md
@@ -56,22 +56,22 @@ By default, npm installs an old release that does not include latest improvement
 
 To upgrade to devel branch, see :
 
-- for linux : [3A3) Optional : Upgrade gtp2ogs.js from old branch to “devel” branch (latest)](/docs/3A3-linux-optional-upgrade-to-devel.md)
-- for windows : [3B3) Optional : Upgrade gtp2ogs from old branch to devel (latest) branch](/docs/3B3-windows-optional-upgrade-to-devel.md)
+- for linux : [3A3) Optional : Upgrade gtp2ogs.js from old branch to “devel” branch (latest)](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3A3-linux-optional-upgrade-to-devel.md)
+- for windows : [3B3) Optional : Upgrade gtp2ogs from old branch to devel (latest) branch](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3B3-windows-optional-upgrade-to-devel.md)
 
 # Optional : workaround for komi not supported by your engine
 
-If your bot engine does not support all komi values, it is likely that some games will fail to start and be played
+If your bot engine does not support all komi values, it is likely that some games will fail to start.
 
-For example [PhoenixGo](https://github.com/Tencent/PhoenixGo) only supports a komi of 7.5, and any other komi value chosen will crash the bot (including the widespread 6.5 and 0.5 komi)
+For example, [PhoenixGo](https://github.com/Tencent/PhoenixGo) only supports a komi of 7.5, and any other komi value chosen will crash the bot (including the widespread 6.5 and 0.5 komi)
 
-There is no `--komi` gtp2ogs argument yet (that would reject games that do not have the wanted komi), however there is the  workaround of editing gtp2ogs.js so that it will tell your engine that the komi wil always be the set value (for example 7.5), even if it's not true on the OGS game.
+There is no `--komi` gtp2ogs argument yet (that would reject games that do not have the wanted komi), however there is a   workaround : you can edit gtp2ogs.js file so that it will always tell your engine the komi is the set value (for example 7.5), even if it's not true in the OGS game.
 
-This method will result in some uncorrect scoring (so do not use it for ranked games), but at least your engine will be able to play
+This method will result in some uncorrect scoring (so do not use it for ranked games), but at least your engine will be able to play.
 
 For more details, see : 
-- for linux : [3A4) Optional : Edit the gtp2ogs.js file (for example force komi to 7.5)](3A4-linux-optional-edit-gtp2ogs-js-file.md)
-- for windows : [3B4) Optional : Modify the gtp2ogs.js file (for example force komi to 7.5)](/docs/3B4-windows-optional-edit-gtp2ogs-js-file.md)
+- for linux : [3A4) Optional : Edit the gtp2ogs.js file (for example force komi to 7.5)](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3A4-linux-optional-edit-gtp2ogs-js-file.md)
+- for windows : [3B4) Optional : Modify the gtp2ogs.js file (for example force komi to 7.5)](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3B4-windows-optional-edit-gtp2ogs-js-file.md)
 
 # Options
 

--- a/README.md
+++ b/README.md
@@ -181,3 +181,5 @@ The following options are placed in the above ```<arguments>``` section.  Put a 
 ```
 
 note : a list of gtp2ogs arguments is also available [here](https://github.com/online-go/gtp2ogs/blob/devel/gtp2ogs.js) (ctrl+f "describe")
+
+note 2 : on OGS, black player will always get the handicap stones regardless of rank difference (if null (automatic) komi is selected, the komi will be 0.5 , but you can restrict allowed komi for example to only 7.5 or null with `--komi 7.5,null` , or only 7.5 komi with `--komi 7.5` for example

--- a/README.md
+++ b/README.md
@@ -15,21 +15,35 @@ with [OGS (Online-Go.com Server)](https://online-go.com/)
 
 #### 2. Run
 
-For linux in terminal, or for windows in a node.js command prompt (as admin) :
+- For linux in terminal, or for windows in a node.js command prompt (as admin) :
 
 ```
-npm install gtp2ogs
+sudo npm install -g gtp2ogs
 ```
-If npm install gives you an error, try doing the above commands with `npm install -g gtp2ogs` instead (add `sudo` for linux, run as admin for windows).
 
-On all operating systems, gtp2ogs will be installed in 2 different directories, but the one that needs to be run with node is gtp2ogs.js in node_modules directory
+default path install is : 
+> /usr/lib/node_modules/gtp2ogs/gtp2ogs.js
+
+- For windows, open a node.js command prompt as admin, then run this command :
+
+```
+npm install -g gtp2ogs
+```
+
+default path install is something like this :
+> C:\Users\yourusername\AppData\Roaming\npm\node_modules\gtp2ogs\gtp2ogs.js
+
+
+On all operating systems, gtp2ogs will be installed in 2 different directories, but **the one that needs to be run with node is gtp2ogs.js in node_modules directory**
 
 #### 3. Optionally install any missing node.js packages if basic usage below fails, such as:
-  
+ 
+(as `sudo` for linux, and as admin for windows)
+ 
 ```
-npm install socket.io-client
-npm install optimist
-npm install tracer
+npm install -g socket.io-client
+npm install -g optimist
+npm install -g tracer
   ```
 
 # Basic usage
@@ -37,7 +51,7 @@ npm install tracer
 For linux (preferably as sudo) :
 
 ```
-node /path/to/node_modules/gtp2ogs/gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- /path/to/your/ai/runfile.file <bot argument1> <bot argument2>
+node /usr/lib/node_modules/gtp2ogs/gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- /path/to/your/ai/runfile.file <bot argument1> <bot argument2>
 ```
 
 For windows (preferably as admin) : 
@@ -46,11 +60,11 @@ For windows (preferably as admin) :
 pushd C:\Program Files\nodejs && node.exe C:\path\to\node_modules\gtp2ogs\gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- C:\Users\path\to\your\ai\executable.exe <bot arguments>
 ```
 
-note : for all operating systemps, in ` -- `, the spaces after `<gtp2ogsarguments>` and before `/path/to/your/bot.executable` are important : they separate gtp2ogs arguments from your bot arguments
+note : for all operating systems, in ` -- `, the spaces after `<gtp2ogsarguments>` and before `/path/to/your/bot.executable` are important : they separate gtp2ogs arguments from your bot arguments
   
 note 2 : to play on [beta OGS server](https://beta.online-go.com/) instead of the [OGS server](https://online-go.com/), add the `-- beta` argument
 
-# Optional : To upgrade to devel branch
+# Optional : Upgrade to devel branch
 
 By default, npm installs an old release that does not include latest improvements and fixes
 
@@ -110,6 +124,8 @@ The following options are placed in the above ```<arguments>``` section.  Put a 
 
   ```--boardsize```  Board size(s) to accept (default 9,13,19)
 
+  ```--komi``` Allowed komi values : when --komi is not used default is "null" (Automatic) and other komi values will be rejected, but if --komi argument is used with the wanted komi value(s) then only these values will be allowed instead,  example : `--komi null,0.5,7.5` or `--komi 7.5`
+
   ```--ban```  Comma separated list of user names or IDs (e.g.  UserA,UserB,UserC  do not put spaces in between)
 
   ```--banranked```  Comma separated list of user names or IDs who are banned from playing ranked games
@@ -156,7 +172,11 @@ The following options are placed in the above ```<arguments>``` section.  Put a 
 
   ```--unrankedonly```  Only accept unranked matches
 
+  ```--minhandicap```  Min handicap for all games
+
   ```--maxhandicap```  Max handicap for all games
+
+  ```--minrankedhandicap```  Min handicap for ranked games
 
   ```--maxrankedhandicap```  Max handicap for ranked games
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install tracer
 For linux (preferably as sudo) :
 
 ```
-node /path/to/node_modules/gtp2ogs/gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- path/to/your/ai/runfile.file <bot argument1> <bot argument2>
+node /path/to/node_modules/gtp2ogs/gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- /path/to/your/ai/runfile.file <bot argument1> <bot argument2>
 ```
 
 For windows (preferably as admin) : 
@@ -46,7 +46,7 @@ For windows (preferably as admin) :
 pushd C:\Program Files\nodejs && node.exe C:\path\to\node_modules\gtp2ogs\gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- C:\Users\path\to\your\ai\executable.exe <bot arguments>
 ```
 
-note : for all operating systemps, in ` -- `, the spaces after <gtp2ogsarguments> and before path/to/your/bot.executable are important : they separate gtp2ogs arguments from your bot arguments
+note : for all operating systemps, in ` -- `, the spaces after `<gtp2ogsarguments>` and before `/path/to/your/bot.executable` are important : they separate gtp2ogs arguments from your bot arguments
   
 note 2 : to play on [beta OGS server](https://beta.online-go.com/) instead of the [OGS server](https://online-go.com/), add the `-- beta` argument
 

--- a/README.md
+++ b/README.md
@@ -51,18 +51,20 @@ npm install -g tracer
 For linux (preferably as sudo) :
 
 ```
-node /usr/lib/node_modules/gtp2ogs/gtp2ogs.js --username <yourbotusername> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- /path/to/your/ai/runfile.file <bot argument1> <bot argument2>
+node /usr/lib/node_modules/gtp2ogs/gtp2ogs.js --username <yourbotusername> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- /path/to/your/ai/runfile.file <botargument1> <botargument2>
 ```
 
 For windows (preferably as admin) : 
 
 ```
-pushd C:\Program Files\nodejs && node.exe C:\path\to\node_modules\gtp2ogs\gtp2ogs.js --username <yourbotusername> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- C:\Users\path\to\your\ai\executable.exe <bot arguments>
+pushd C:\Program Files\nodejs && node.exe C:\replace\with\full\path\to\node_modules\gtp2ogs\gtp2ogs.js --username <yourbotusername> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- C:\Users\path\to\your\ai\executable.exe <botargument1> <botargument2>
 ```
 
 note : for all operating systems, in ` -- `, the spaces after `<gtp2ogsarguments>` and before `/path/to/your/bot.executable` are important : they separate gtp2ogs arguments from your bot arguments
+
+note 2 : the number of <gtp2ogsarguments> and <botarguments> is not limited, here only 2 were shown but it possible to use for example 3, 8, or more
   
-note 2 : to play on [beta OGS server](https://beta.online-go.com/) instead of the [OGS server](https://online-go.com/), add the `-- beta` argument
+note 3 : to play on [beta OGS server](https://beta.online-go.com/) instead of the [OGS server](https://online-go.com/), add the `-- beta` argument
 
 # Optional : Upgrade to devel branch
 
@@ -77,8 +79,7 @@ To upgrade to devel branch, see :
 
 The following options are placed in the above ```<arguments>``` section.  Put a space in between options when there are more than one.  Also put a space in between the option and the parameter like:
 
-```
---startupbuffer 2 --boardsize 13,19 --ban UserX,playerY ```
+  ```--startupbuffer 2 --boardsize 13,19 --ban UserX,playerY ```
 
   ```--host```  OGS Host to connect to (default online-go.com)
 
@@ -165,6 +166,8 @@ The following options are placed in the above ```<arguments>``` section.  Put a 
   ```--minrankedhandicap```  Min handicap for ranked games
 
   ```--maxrankedhandicap```  Max handicap for ranked games
+
+  ```--minunrankedhandicap```  Min handicap for unranked games
 
   ```--maxunrankedhandicap```  Max handicap for unranked games
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ npm install -g tracer
 For linux (preferably as sudo) :
 
 ```
-node /usr/lib/node_modules/gtp2ogs/gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- /path/to/your/ai/runfile.file <bot argument1> <bot argument2>
+node /usr/lib/node_modules/gtp2ogs/gtp2ogs.js --username <yourbotusername> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- /path/to/your/ai/runfile.file <bot argument1> <bot argument2>
 ```
 
 For windows (preferably as admin) : 
 
 ```
-pushd C:\Program Files\nodejs && node.exe C:\path\to\node_modules\gtp2ogs\gtp2ogs.js --botid <id> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- C:\Users\path\to\your\ai\executable.exe <bot arguments>
+pushd C:\Program Files\nodejs && node.exe C:\path\to\node_modules\gtp2ogs\gtp2ogs.js --username <yourbotusername> --apikey <apikey> <gtp2ogsargument1> <gtp2ogsargument2> -- C:\Users\path\to\your\ai\executable.exe <bot arguments>
 ```
 
 note : for all operating systems, in ` -- `, the spaces after `<gtp2ogsarguments>` and before `/path/to/your/bot.executable` are important : they separate gtp2ogs arguments from your bot arguments
@@ -175,6 +175,6 @@ The following options are placed in the above ```<arguments>``` section.  Put a 
   ```--nopauseunranked```  Do not allow unranked games to be paused
 
   ```--hidden```  Hides the botname from the OGS game creation bot list
+```
 
 note : a list of gtp2ogs arguments is also available [here](https://github.com/online-go/gtp2ogs/blob/devel/gtp2ogs.js) (ctrl+f "describe")
-

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -53,10 +53,13 @@ let optimist = require("optimist")
     .describe('boardsize', 'Board size(s) to accept')
     .string('boardsize')
     .default('boardsize', '9,13,19')
-    .describe('komi', 'Allowed komi values : when --komi is not used default is "null" (Automatic) and other komi values will be rejected, but if --komi argument is used with the wanted komi value(s) then only these values will be allowed instead,  example : --komi null,0.5,7.5 or --komi 7.5)
+    .describe('komi', 'Allowed komi values')
     .string('komi')
-    // TODO : re-add the ability to accept any komi value (other than null) when --komi is not used
     .default('komi', 'null')
+    // behaviour : when --komi is not used default is "null" (Automatic) and other komi values will be rejected, 
+    //but if --komi argument is used with the wanted komi value(s) then only these values will be allowed instead
+    // example : --komi null,0.5,7.5 or --komi 7.5
+    // TODO : re-add the ability to accept any komi value (other than null) when --komi is not used
     .describe('ban', 'Comma separated list of user names or IDs')
     .string('ban')
     .describe('banranked', 'Comma separated list of user names or IDs')
@@ -1353,7 +1356,7 @@ class Connection {
 
         if(!allowed_komi[notification.komi]) {
             conn_log("komi value " + notification.komi + " is not an allowed komi, allowed komi are" + argv.komi + ", rejecting challenge");
-            return { reject: true, msg: "Komi value different from " + argv.komi + " is not allowed ; note : -null- means -automatic- komi};
+            return { reject: true, msg: "Komi value different from " + argv.komi + " is not allowed, and null is the automatic komi. "};
         }
 
         if (!allowed_speeds[t.speed]) {

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1353,7 +1353,7 @@ class Connection {
 
         if(!allowed_komi[notification.komi]) {
             conn_log("komi value " + notification.komi + " is not an allowed komi, allowed komi are" + argv.komi + ", rejecting challenge");
-            return { reject: true, msg: "Komi value different from " + argv.komi + " is not allowed " };
+            return { reject: true, msg: "Komi value different from " + argv.komi + " is not allowed ; note : -null- means -automatic- komi};
         }
 
         if (!allowed_speeds[t.speed]) {

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1356,7 +1356,7 @@ class Connection {
 
         if(!allowed_komi[notification.komi]) {
             conn_log("komi value " + notification.komi + " is not an allowed komi, allowed komi are" + argv.komi + ", rejecting challenge");
-            return { reject: true, msg: "Komi value different from " + argv.komi + " is not allowed, and null is the automatic komi. "};
+            return { reject: true, msg: "Komi " + notification.komi + " is different from " + argv.komi + " : komi value not allowed, please note that the automatic komi is called null. "};
         }
 
         if (!allowed_speeds[t.speed]) {

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -94,6 +94,7 @@ let optimist = require("optimist")
     .describe('unrankedonly', 'Only accept unranked matches')
     .describe('minhandicap', 'Min handicap for all games')
     .describe('maxhandicap', 'Max handicap for all games')
+    .describe('minrankedhandicap', 'Min handicap for ranked games')
     .describe('maxrankedhandicap', 'Max handicap for ranked games')
     .describe('minunrankedhandicap', 'Min handicap for unranked games')
     .describe('maxunrankedhandicap', 'Max handicap for unranked games')
@@ -101,7 +102,6 @@ let optimist = require("optimist")
     .describe('nopauseranked', 'Do not allow ranked games to be paused')
     .describe('nopauseunranked', 'Do not allow unranked games to be paused')
     .describe('hidden', 'Don\'t list the bot in the public challenge list')
-
 ;
 let argv = optimist.argv;
 


### PR DESCRIPTION
@roy7 @anoek 

Many improvements over the old devel

general look is here : https://github.com/wonderingabout/gtp2ogs/tree/tutorial-minhandicap-komi

`--minhandicap` is just the reverse of max handicap : 

![minhandicap](https://user-images.githubusercontent.com/38690718/50378755-8b363980-0639-11e9-91fd-cb3e1dab876b.png)

added a new `--komi` argument, that gives a reject game message
it was inspired on the boardsize argument

behaviour : 
- when no argument is used, only accepted value is "automatic" (default = null) (including the widespread 6.5, 7.5, 0.5 for handicap, etc..., but no custom komi is allowed, which is not supported by most bots anyways)

![nokomi](https://user-images.githubusercontent.com/38690718/50378975-f5e97400-063d-11e9-94ae-33984aa4592d.png)


- when `--komi` is used, the allowed komi are instead only the specified value(s)

for example with `--komi 7.5` : 

![komi75](https://user-images.githubusercontent.com/38690718/50378976-f8e46480-063d-11e9-9d5b-5fc1b51cf864.png)

for example with `--komi 7.5,0.5,null,220.5` : 

![komimany](https://user-images.githubusercontent.com/38690718/50378979-fda91880-063d-11e9-99ed-20deb1dbd80f.png)


todo : 
when no komi argument is used, re-add the ability to accept all komi values, including custom ones 