### PR TITLE
Boot priority for reject messages (for better user experience)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,21 @@ or another example `--komi 7.5` will only accept komi value 7.5 and will reject 
 
   ```--hidden```  Hides the botname from the OGS game "Play against computer" bot list (but it can still accept challenges)
 
-note : a list of gtp2ogs arguments is also available [here](https://github.com/online-go/gtp2ogs/blob/devel/gtp2ogs.js) (ctrl+f "describe")
+## notes :
 
-note 2 : on OGS, black player will always get the handicap stones regardless of rank difference (if null (automatic) komi is selected, the komi will be 0.5 , but you can restrict allowed komi for example to only 7.5 or null with `--komi 7.5,null` , or only 7.5 komi with `--komi 7.5` for example
+#### 1.
+
+a list of gtp2ogs arguments is also available [here](https://github.com/online-go/gtp2ogs/blob/devel/gtp2ogs.js) (ctrl+f "describe")
+
+#### 2 : 
+
+on OGS, black player will always get the handicap stones regardless of rank difference (if null (automatic) komi is selected, the komi will be 0.5 , 
+
+but you can restrict allowed komi for example to only 7.5 or null with `--komi 7.5,null` , or only 7.5 komi with `--komi 7.5` to play handicap games with 7.5 komi if your bot does not support 0.5 komi value.
+
+#### 3 : 
+
+when using the "msg" arguments (`--greeting` , `--farewell` , `--rejectnew --rejectnewmsg` , some special characters will make gtp2ogs crash, such as `!!` (two times `!`) , so test special characters in your messages with caution 
+
+these special characters have been tested to work on messages, among others :  `!` (one time `!`) , `?` , `,` , `(` , `)` , `:` , `;` 
+

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1390,12 +1390,12 @@ class Connection {
 
         if (user.ranking < argv.minrank) {
             conn_log(user.username + " ranking too low: " + user.ranking);
-            return { reject: true, msg: "Minimum rank allowed is " + argv.minrank + " , your rank is " + user.ranking + " your rank is too low. " };
+            return { reject: true, msg: "Minimum rank allowed is " + argv.minrank + " (in bot ranking units), your rank is " + user.ranking + " (in bot ranking units), your rank is too low, try again when your rank is high enough." };
         }
 
         if (user.ranking > argv.maxrank) {
             conn_log(user.username + " ranking too high: " + user.ranking);
-            return { reject: true, msg: "Maximum rank allowed is " + argv.maxrank + " , your rank is " + user.ranking + " your rank is too high. " };
+            return { reject: true, msg: "Maximum rank allowed is " + argv.maxrank + " (in bot ranking units), your rank is " + user.ranking + " (in bot ranking units), your rank is too high, try again when your rank is low enough." };
         }
 
         return { reject: false }; // OK !
@@ -1572,10 +1572,10 @@ class Connection {
             return { reject: true, msg: REJECTNEWMSG };
         }
 
-        let c = this.checkGameSettings(notification);
+        let c = this.checkUser(notification);
         if (c.reject)  return c;
 
-        c = this.checkUser(notification);
+        c = this.checkGameSettings(notification);
         if (c.reject)  return c;
 
         return { reject: false };  /* All good. */


### PR DESCRIPTION
Hi,

i noticed many times that it's very frustrating for the user to fill all requirements that the bot asks (time settings, komi, handicap, etc...), and in the end to have game rejected due to too low ranking :cry: 

so i fixed this and tested it on beta ogs

it works as intended (rejects all games with the wanted priority order, and accepts games after that) :+1: 

new boot priority order now : 
(may have changed slighlty since i wrote this yesterday)

```
*most important*
0.1) maxtotalgames and similar (reject games if max limit is reached without asking anything else (add "try again later" if not already existing on reject message))
0.2) any other reject condition (unranked only, user banned, etc..). Pointless to ask all time settings and all but disppoint the user in the end with a reject
1) rank (pointless to check anything else if rank is too low)
2) boardsize (pointless to continue if board size is not allowed)
3) handicap
4) komi (if user wants to play a handicap game, after stone number is correct, then ask about komi (0.5 or 7.5 only, etc..)
* secondary things, when most important things are settled*
5) speed (live, etc..)
6) time controls (fischer, byoyomi, etc...)
7)  time settings (min main time)
8) period number (asking twice seconds feels like the bot is ignoring our requests, from the user perspective, so adding  number of periods inbetween to cool a bit)
9) time settings 2 (period time, etc...)
```

i also used this opportunity to improve a little more the reject messages (minor changes, clearer for the user)

i suggest you test it on beta ogs with 

```
--debug --noclock --maxhandicap 0 --minmaintime 60 --maxmaintime 120 --minperiods 5 --maxperiods 10 --komi null --unrankedonly --boardsize 19 --speed live --timecontrol fischer,byoyomi --minrank 1d
```

try those to see how the bot behaves
really better user experience :+1: 

note : 

added a note about some special characters that crash gtp2ogs if used in the "msg" arguments (greeting , farewell , rejectnew rejectnewmsg)