### PR TITLE
hrt : display human readable rank, fix rank calculation, other minor changes

### DIFF
--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1772,6 +1772,7 @@ class Connection {
         }
 
         ////// begining of *** UHMAEAT : Universal Highly Modulable And Expandable Argv Tree ***
+        ///// for maintime 
 
         if (argv.minmaintime || argv.minmaintimeranked || argv.minmaintimeunranked || argv.maxmaintime || argv.maxmaintimeranked || argv.maxmaintimeunranked) {
             // later the t.time_control can't be used for rule detection for some reason,
@@ -1900,107 +1901,170 @@ class Connection {
 
         ////// end of *** UHMAEAT : Universal Highly Modulable And Expandable Argv Tree ***
 
+        // making period number to choose being more user friendly
+        // TO UHMAEAT it too : 
+        // let examplePeriodsNumber = 0;
+        // let examplePeriodsSentence = ` ,for example ${examplePeriodsNumber} x ${examplePeriodtimeNumber}`;
+
         if (argv.minperiods && (t.periods < argv.minperiods)) {
             conn_log(user.username + " wanted too few periods: " + t.periods);
-            return { reject: true, msg: "Minimum number of periods is " + argv.minperiods + " , please increase the number of periods, for example " + argv.minperiods + " x 30 seconds " };
+            return { reject: true, msg: "Minimum number of periods is " + argv.minperiods + " , please increase the number of periods" };
         }
 
         if (argv.minperiodsranked && (t.periods < argv.minperiodsranked) && notification.ranked) {
             conn_log(user.username + " wanted too few periods ranked: " + t.periods);
-            return { reject: true, msg: "Minimum number of periods for ranked games is " + argv.minperiodsranked + " , please increase the number of periods, for example " + argv.minperiodsranked + " x 30 seconds " };
+            return { reject: true, msg: "Minimum number of periods for ranked games is " + argv.minperiodsranked + " , please increase the number of periods" };
         }
 
         if (argv.minperiodsunranked && (t.periods < argv.minperiodsunranked) && !notification.ranked) {
             conn_log(user.username + " wanted too few periods unranked: " + t.periods);
-            return { reject: true, msg: "Minimum number of periods for unranked games is " + argv.minperiodsunranked + " , please increase the number of periods, for example " + argv.minperiodsunranked + " x 30 seconds " };
+            return { reject: true, msg: "Minimum number of periods for unranked games is " + argv.minperiodsunranked + " , please increase the number of periods" };
         }
 
         if (t.periods > argv.maxperiods) {
             conn_log(user.username + " wanted too many periods: " + t.periods);
-            return { reject: true, msg: "Maximum number of periods is " + argv.maxperiods + " , please reduce the number of periods, for example " + argv.maxperiods + " x 30 seconds " };
+            return { reject: true, msg: "Maximum number of periods is " + argv.maxperiods + " , please reduce the number of periods" };
         }
 
         if (t.periods > argv.maxperiodsranked && notification.ranked) {
             conn_log(user.username + " wanted too many periods ranked: " + t.periods);
-            return { reject: true, msg: "Maximum number of periods for ranked games is " + argv.maxperiodsranked + " , please reduce the number of periods, for example " + argv.maxperiodsranked + " x 30 seconds " };
+            return { reject: true, msg: "Maximum number of periods for ranked games is " + argv.maxperiodsranked + " , please reduce the number of periods" };
         }
 
         if (t.periods > argv.maxperiodsunranked && !notification.ranked) {
             conn_log(user.username + " wanted too many periods unranked: " + t.periods);
-            return { reject: true, msg: "Maximum number of periods for unranked games is " + argv.maxperiodsunranked + " , please reduce the number of periods, for example " + argv.maxperiodsunranked + " x 30 seconds " };
+            return { reject: true, msg: "Maximum number of periods for unranked games is " + argv.maxperiodsunranked + " , please reduce the number of periods" };
         }
 
-        if (argv.minperiodtime &&
-            (      (t.period_time    < argv.minperiodtime)
-                || (t.time_increment < argv.minperiodtime)
-                || (t.per_move       < argv.minperiodtime)
-                || ((t.period_time / t.stones_per_period) < argv.minperiodtime)
-            ))
-        {
-            let humanReadableTime = timespanToDisplayString(argv.minperiodtime);
-            conn_log(user.username + " wanted period time too short");
-            return { reject: true, msg: "Minimum is " + humanReadableTime + " per period, please increase period time. \n - If you use Fischer, you need to change -increment time- " };
+        ////// begining of *** UHMAEAT : Universal Highly Modulable And Expandable Argv Tree ***
+        // for period time //
+
+        if (argv.minperiodtime || argv.minperiodtimeranked || argv.minperiodtimeunranked || argv.maxperiodtime || argv.maxperiodtimeranked || argv.maxperiodtimeunranked) {
+            // later the t.time_control can't be used for rule detection for some reason,
+            // so storing it now in a string while we can
+            // also, whenever before TimecontrolString is going to be tested,
+            // we always make sure it has the latest value
+            // this avoids TimecontrolString being frozen on the same value independently from what user chooses, 
+            // e.g. stuck on "absolute"  
+
+            // for fischer, byoyomi, or canadian, we use our UHMAEAT !
+            let universalPeriodtimeMinimumMaximumSentence = "";    // minimum
+            let universalPeriodtimeTimecontrolSentence = "";       // period time - initial time and/or max time, etc..
+            let universalPeriodtimeForRankedUnrankedSentence = ""; // +/- for ranked/unranked games is
+            let universalPeriodtimeNumber = 0;                     // for example 600 (600 seconds)
+            let universalPeriodtimeToString = "";                  // for example "10 minutes"  = timespanToDisplayString(argv.xxx)
+            let universalPeriodtimeIncreaseDecreaseSentence = "";  // , please increase/decrease
+                                                                 // period time - PeriodtimeTimecontrolSentence again
+            let universalPeriodtimeEndingSentence = "";            // optionnal, for example in canadian, adds explanation
+            let universalPeriodtimeTimecontrolString = String(t.time_control);/*
+            "fischer" , "simple", "byoyomi" , "canadian" , "absolute"*/
+
+            if (argv.minperiodtime || argv.minperiodtimeranked || argv.minperiodtimeunranked) {
+                universalPeriodtimeMinimumMaximumSentence = "Minimum ";
+                universalPeriodtimeIncreaseDecreaseSentence = ", please increase ";
+                let universalPeriodtimeConnSentence = user.username + " wanted period time below minimum period time ";
+                if (argv.minperiodtime) {
+                    universalPeriodtimeNumber = argv.minperiodtime;
+                    universalPeriodtimeToString = timespanToDisplayString(argv.minperiodtime);
+                    universalPeriodtimeForRankedUnrankedSentence = "is ";
+                }
+                if (argv.minperiodtimeranked && notification.ranked) {
+                    universalPeriodtimeNumber = argv.minperiodtimeranked;
+                    universalPeriodtimeToString = timespanToDisplayString(argv.minperiodtimeranked);
+                    universalPeriodtimeForRankedUnrankedSentence = "for ranked games is ";
+                }
+                if (argv.minperiodtimeunranked && !notification.ranked) {
+                    universalPeriodtimeNumber = argv.minperiodtimeunranked;
+                    universalPeriodtimeToString = timespanToDisplayString(argv.minperiodtimeunranked);
+                    universalPeriodtimeForRankedUnrankedSentence = "for unranked games is ";
+                 }
+                // now just before TimecontrolString is being tested, we again make sure it has the latest value
+                universalPeriodtimeTimecontrolString = String(t.time_control);/*
+                "fischer", "byoyomi", "canadian" */
+
+                // sanity check : if not fischer, not byoyomi, not canadian
+                if ((universalPeriodtimeTimecontrolString !== "fischer") && (universalPeriodtimeTimecontrolString !== "byoyomi") && (universalPeriodtimeTimecontrolString !== "canadian")) {
+                    conn_log ("error, could not find time control in " + t.time_control);
+                    return { reject : true, msg: "error, could not find time control in " + t.timecontrol};
+                }                
+
+                // if sanity check passes :
+                if ((universalPeriodtimeTimecontrolString === "fischer") || (universalPeriodtimeTimecontrolString === "byoyomi") || (universalPeriodtimeTimecontrolString === "canadian")) {
+                    if ((universalPeriodtimeTimecontrolString === "fischer") && (t.time_increment < universalPeriodtimeNumber)) {
+                        universalPeriodtimeTimecontrolSentence = "Increment Time ";
+                        universalPeriodtimeEndingSentence = ".";
+                        conn_log(universalPeriodtimeConnSentence + universalPeriodtimeToString + " in " + universalPeriodtimeTimecontrolString);
+                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
+                    }
+                    if (universalPeriodtimeTimecontrolString === "byoyomi" && t.period_time < universalPeriodtimeNumber) {
+                        universalPeriodtimeTimecontrolSentence = "Period Time ";
+                        universalPeriodtimeEndingSentence = ".";
+                        conn_log(universalPeriodtimeConnSentence + universalPeriodtimeToString + " in " + universalPeriodtimeTimecontrolString);
+                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
+                    }
+                    if (universalPeriodtimeTimecontrolString === "canadian" && (t.period_time < universalPeriodtimeNumber)) {
+                        universalPeriodtimeTimecontrolSentence = "Period Time for " + t.stones_per_period + " stones " ;
+                        universalPeriodtimeEndingSentence = ".";
+                        conn_log(universalPeriodtimeConnSentence + universalPeriodtimeToString + " in " + universalPeriodtimeTimecontrolString);
+                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
+                    }
+                }
+            }
+
+            if (argv.maxperiodtime || argv.maxperiodtimeranked || argv.maxperiodtimeunranked) {
+                universalPeriodtimeMinimumMaximumSentence = "Maximum ";
+                universalPeriodtimeIncreaseDecreaseSentence = ", please reduce ";
+                let universalPeriodtimeConnSentence = user.username + " wanted period time above maximum period time ";
+                if (argv.maxperiodtime) {
+                    universalPeriodtimeNumber = argv.maxperiodtime;
+                    universalPeriodtimeToString = timespanToDisplayString(argv.maxperiodtime);
+                    universalPeriodtimeForRankedUnrankedSentence = "is ";
+                }
+                if (argv.maxperiodtimeranked && notification.ranked) {
+                    universalPeriodtimeNumber = argv.maxperiodtimeranked;
+                    universalPeriodtimeToString = timespanToDisplayString(argv.maxperiodtimeranked);
+                    universalPeriodtimeForRankedUnrankedSentence = "for ranked games is ";
+                }
+                if (argv.maxperiodtimeunranked && !notification.ranked) {
+                    universalPeriodtimeNumber = argv.maxperiodtimeunranked;
+                    universalPeriodtimeToString = timespanToDisplayString(argv.maxperiodtimeunranked);
+                    universalPeriodtimeForRankedUnrankedSentence = "for unranked games is ";
+                }
+                // now just before TimecontrolString is being tested, we again make sure it has the latest value
+                universalPeriodtimeTimecontrolString = String(t.time_control);/*
+                "fischer", "byoyomi", "canadian" */
+
+                // sanity check : if not fischer, not byoyomi, not canadian
+                if ((universalPeriodtimeTimecontrolString !== "fischer") && (universalPeriodtimeTimecontrolString !== "byoyomi") && (universalPeriodtimeTimecontrolString !== "canadian")) {
+                    conn_log ("error, could not find time control in " + t.time_control);
+                    return { reject : true, msg: "error, could not find time control in " + t.timecontrol};
+                }                
+
+                // if sanity check passes :
+                if ((universalPeriodtimeTimecontrolString === "fischer") || (universalPeriodtimeTimecontrolString === "byoyomi") || (universalPeriodtimeTimecontrolString === "canadian")) {
+                    if ((universalPeriodtimeTimecontrolString === "fischer") && (t.time_increment > universalPeriodtimeNumber)) {
+                        universalPeriodtimeTimecontrolSentence = "Increment Time ";
+                        universalPeriodtimeEndingSentence = ".";
+                        conn_log(universalPeriodtimeConnSentence + universalPeriodtimeToString + " in " + universalPeriodtimeTimecontrolString);
+                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
+                    }
+                    if (universalPeriodtimeTimecontrolString === "byoyomi" && t.period_time > universalPeriodtimeNumber) {
+                        universalPeriodtimeTimecontrolSentence = "Period Time ";
+                        universalPeriodtimeEndingSentence = ".";
+                        conn_log(universalPeriodtimeConnSentence + universalPeriodtimeToString + " in " + universalPeriodtimeTimecontrolString);
+                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
+                    }
+                    if (universalPeriodtimeTimecontrolString === "canadian" && (t.period_time > universalPeriodtimeNumber)) {
+                        universalPeriodtimeTimecontrolSentence = "Period Time for " + t.stones_per_period + " stones " ;
+                        universalPeriodtimeEndingSentence = ".";
+                        conn_log(universalPeriodtimeConnSentence + universalPeriodtimeToString + " in " + universalPeriodtimeTimecontrolString);
+                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
+                    } 
+                }
+            }
         }
 
-        if (argv.maxperiodtime &&
-            (      (t.period_time    > argv.maxperiodtime)
-                || (t.time_increment > argv.maxperiodtime)
-                || (t.per_move       > argv.maxperiodtime)
-                || ((t.period_time / t.stones_per_period) > argv.maxperiodtime)
-            ))
-        {
-            let humanReadableTime = timespanToDisplayString(argv.maxperiodtime);
-            conn_log(user.username + " wanted period time too long");
-            return { reject: true, msg: "Maximum is " + humanReadableTime + " per period, please reduce period time \n - If you use Fischer, you need to change -increment time-" };
-        }
-
-        if (argv.minperiodtimeranked && notification.ranked && 
-            (      (t.period_time    < argv.minperiodtimeranked)
-                || (t.time_increment < argv.minperiodtimeranked)
-                || (t.per_move       < argv.minperiodtimeranked)
-                || ((t.period_time / t.stones_per_period) < argv.minperiodtimeranked)
-            ))
-        {
-            let humanReadableTime = timespanToDisplayString(argv.minperiodtimeranked);
-            conn_log(user.username + " wanted period time ranked too short");
-            return { reject: true, msg: "Minimum is " + humanReadableTime + " per period for ranked games, please increase period time \n - If you use Fischer, you need to change -increment time- " };
-        }
-
-        if (argv.maxperiodtimeranked && notification.ranked &&
-            (      (t.period_time    > argv.maxperiodtimeranked)
-                || (t.time_increment > argv.maxperiodtimeranked)
-                || (t.per_move       > argv.maxperiodtimeranked)
-                || ((t.period_time / t.stones_per_period) > argv.maxperiodtimeranked)
-            ))
-        {
-            let humanReadableTime = timespanToDisplayString(argv.maxperiodtimeranked);
-            conn_log(user.username + " wanted period time ranked too long");
-            return { reject: true, msg: "Maximum is " + humanReadableTime + " per period for ranked games, please reduce period time \n - If you use Fischer, you need to change -increment time- " };
-        }
-
-        if (argv.minperiodtimeunranked && !notification.ranked && 
-            (      (t.period_time    < argv.minperiodtimeunranked)
-                || (t.time_increment < argv.minperiodtimeunranked)
-                || (t.per_move       < argv.minperiodtimeunranked)
-                || ((t.period_time / t.stones_per_period) < argv.minperiodtimeunranked)
-            ))
-        {
-            let humanReadableTime = timespanToDisplayString(argv.minperiodtimeunranked);
-            conn_log(user.username + " wanted period time unranked too short");
-            return { reject: true, msg: "Minimum is " + humanReadableTime + " per period for unranked games, please increase period time \n - If you use Fischer, you need to change -increment time- " };
-        }
-
-        if (argv.maxperiodtimeunranked && !notification.ranked &&
-            (      (t.period_time    > argv.maxperiodtimeunranked)
-                || (t.time_increment > argv.maxperiodtimeunranked)
-                || (t.per_move       > argv.maxperiodtimeunranked)
-                || ((t.period_time / t.stones_per_period) > argv.maxperiodtimeunranked)
-            ))
-        {
-            let humanReadableTime = timespanToDisplayString(argv.maxperiodtimeunranked);
-            conn_log(user.username + " wanted period time unranked too long");
-            return { reject: true, msg: "Maximum is " + humanReadableTime + " seconds per period for unranked games, please reduce period time \n - If you use Fischer, you need to change -increment time- " };
-        }
+        ////// end of *** UHMAEAT : Universal Highly Modulable And Expandable Argv Tree ***
 
         return { reject: false };  // Ok !
 

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1963,10 +1963,8 @@ class Connection {
             let universalPeriodtimeTimecontrolString = String(t.time_control);/*
             "fischer" , "simple", "byoyomi" , "canadian" , "absolute"*/
 
-            // for canadian we add a small explanation how to period convert time //
-            let canadianPeriodtimeConvertedNumber = Number("0"); // e.g. 300 seconds divided by 25 stones = 12 seconds / stone
-            let canadianPeriodtimeConvertedString = String(""); // e.g. "12 seconds per stone"
-            let canadianPeriodtimeConvertedSentence = String(); // e.g. "12 seconds per stone, same as 300 seconds for all the 25 stones"
+            // for canadian we add a small explanation how to understand period time for all stones //
+            let canadianPeriodtimeSentence = ""; // see "canadian" for details
 
             if (argv.minperiodtime || argv.minperiodtimeranked || argv.minperiodtimeunranked) {
                 universalPeriodtimeMinimumMaximumSentence = "Minimum ";
@@ -2015,14 +2013,28 @@ class Connection {
                         universalPeriodtimeTimecontrolSentence = "Period Time for " + t.stones_per_period + " stones " ;
                         universalPeriodtimeEndingSentence = ".";
 
-                        // for canadian we add a small explanation how to period convert time //
-                        canadianPeriodtimeConvertedNumber = t.period_time; // e.g. 300 seconds divided by 25 stones = 12 seconds / stone
-                        canadianPeriodtimeConvertedString = timespanToDisplayString(canadianPeriodtimeConvertedNumber); // human readable time string
-                        canadianPeriodtimeConvertedSentence = `per stone (same as ${canadianPeriodtimeConvertedString} for all the ${t.stones_per_period} stones)`; // e.g. "12 seconds per stone, same as 300 seconds for all the 25 stones"
+                        // for canadian we add a small explanation how to understand period for all stones //
+                        // canadian period time is already for n number of stones, dont divide by stone
+                        // e.g. 300 seconds divided by 25 stones = 12 seconds / stone
+                        // first we reconvert displayedTimeToString
+                        if (argv.minperiodtime) {
+                            universalPeriodtimeNumber = (argv.minperiodtime * t.stones_per_period);
+                            universalPeriodtimeToString = timespanToDisplayString(universalPeriodtimeNumber);
+                        }
+                        if (argv.minperiodtimeranked && notification.ranked) {
+                            universalPeriodtimeNumber = (argv.minperiodtimeranked * t.stones_per_period);
+                            universalPeriodtimeToString = timespanToDisplayString(universalPeriodtimeNumber);
+                        }
+                        if (argv.minperiodtimeunranked && !notification.ranked) {
+                            universalPeriodtimeNumber = (argv.minperiodtimeunranked * t.stones_per_period);
+                            universalPeriodtimeToString = timespanToDisplayString(universalPeriodtimeNumber);
+                        }
+                        // then we add the wanted explanation for canadian number of stones
+                        canadianPeriodtimeSentence = `for all the ${t.stones_per_period} stones`; // e.g. "12 seconds per stone, same as 300 seconds for all the 25 stones"
 
                         universalPeriodtimeEndingSentence = ".";
                         conn_log(universalPeriodtimeConnSentence + universalPeriodtimeToString + " in " + universalPeriodtimeTimecontrolString);
-                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${canadianPeriodtimeConvertedSentence} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
+                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${canadianPeriodtimeSentence} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
                     }
                 }
             }
@@ -2073,14 +2085,28 @@ class Connection {
                     if (universalPeriodtimeTimecontrolString === "canadian" && ((t.period_time / t.stones_per_period) > universalPeriodtimeNumber)) {
                         universalPeriodtimeTimecontrolSentence = "Period Time for " + t.stones_per_period + " stones " ;
 
-                        // for canadian we add a small explanation how to period convert time //
-                        canadianPeriodtimeConvertedNumber = t.period_time; // e.g. 300 seconds divided by 25 stones = 12 seconds / stone
-                        canadianPeriodtimeConvertedString = timespanToDisplayString(canadianPeriodtimeConvertedNumber); // human readable time string
-                        canadianPeriodtimeConvertedSentence = `per stone (same as ${canadianPeriodtimeConvertedString} for all the ${t.stones_per_period} stones)`; // e.g. "12 seconds per stone, same as 300 seconds for all the 25 stones"
+                        // for canadian we add a small explanation how to understand period for all stones //
+                        // canadian period time is already for n number of stones, dont divide by stone
+                        // e.g. 300 seconds divided by 25 stones = 12 seconds / stone
+                        // first we reconvert displayedTimeToString
+                        if (argv.maxperiodtime) {
+                            universalPeriodtimeNumber = (argv.maxperiodtime * t.stones_per_period);
+                            universalPeriodtimeToString = timespanToDisplayString(universalPeriodtimeNumber);
+                        }
+                        if (argv.maxperiodtimeranked && notification.ranked) {
+                            universalPeriodtimeNumber = (argv.maxperiodtimeranked * t.stones_per_period);
+                            universalPeriodtimeToString = timespanToDisplayString(universalPeriodtimeNumber);
+                        }
+                        if (argv.maxperiodtimeunranked && !notification.ranked) {
+                            universalPeriodtimeNumber = (argv.maxperiodtimeunranked * t.stones_per_period);
+                            universalPeriodtimeToString = timespanToDisplayString(universalPeriodtimeNumber);
+                        }
+                        // then we add the wanted explanation for canadian number of stones
+                        canadianPeriodtimeSentence = `for all the ${t.stones_per_period} stones`; // e.g. "12 seconds per stone, same as 300 seconds for all the 25 stones"
 
                         universalPeriodtimeEndingSentence = ".";
                         conn_log(universalPeriodtimeConnSentence + universalPeriodtimeToString + " in " + universalPeriodtimeTimecontrolString);
-                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${canadianPeriodtimeConvertedSentence} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
+                        return { reject : true, msg:  `${universalPeriodtimeMinimumMaximumSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeForRankedUnrankedSentence} ${universalPeriodtimeToString} ${canadianPeriodtimeSentence} ${universalPeriodtimeIncreaseDecreaseSentence} ${universalPeriodtimeTimecontrolSentence} ${universalPeriodtimeEndingSentence}` };
                     } 
                 }
             }

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1812,27 +1812,34 @@ class Connection {
                 // now just before TimecontrolString is being tested, we again make sure it has the latest value
                 universalMaintimeTimecontrolString = String(t.time_control);/*
                 "fischer", "byoyomi", "canadian" */
-                conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
-                if ((universalMaintimeTimecontrolString === "fischer") && ((t.initial_time < universalMaintimeNumber) || (t.max_time < universalMaintimeNumber))) {
-                    universalMaintimeTimecontrolSentence = "Initial Time and/or Max Time ";
-                    universalMaintimeEndingSentence = ".";
-                }
-                if (universalMaintimeTimecontrolString === "byoyomi" && t.main_time < universalMaintimeNumber) {
-                    universalMaintimeTimecontrolSentence = "Main Time ";
-                    universalMaintimeEndingSentence = ".";
-                }
-                if (universalMaintimeTimecontrolString === "canadian" && t.main_time < universalMaintimeNumber) {
-                    universalMaintimeTimecontrolSentence = "Main Time ";
-                    universalMaintimeEndingSentence = "."; 
-                }
+
                 // sanity check : if not fischer, not byoyomi, not canadian
                 if ((universalMaintimeTimecontrolString !== "fischer") && (universalMaintimeTimecontrolString !== "byoyomi") && (universalMaintimeTimecontrolString !== "canadian")) {
                     conn_log ("error, could not find time control in " + t.time_control);
                     return { reject : true, msg: "error, could not find time control in " + t.timecontrol};
-                }
-                // if sanity check passes :
-                return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+                }                
 
+                // if sanity check passes :
+                if ((universalMaintimeTimecontrolString === "fischer") || (universalMaintimeTimecontrolString === "byoyomi") || (universalMaintimeTimecontrolString === "canadian")) {
+                    if ((universalMaintimeTimecontrolString === "fischer") && ((t.initial_time < universalMaintimeNumber) || (t.max_time < universalMaintimeNumber))) {
+                        universalMaintimeTimecontrolSentence = "Initial Time and/or Max Time ";
+                        universalMaintimeEndingSentence = ".";
+                        conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
+                        return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+                    }
+                    if (universalMaintimeTimecontrolString === "byoyomi" && t.main_time < universalMaintimeNumber) {
+                        universalMaintimeTimecontrolSentence = "Main Time ";
+                        universalMaintimeEndingSentence = ".";
+                        conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
+                        return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+                    }
+                    if (universalMaintimeTimecontrolString === "canadian" && t.main_time < universalMaintimeNumber) {
+                        universalMaintimeTimecontrolSentence = "Main Time ";
+                        universalMaintimeEndingSentence = ".";
+                        conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
+                        return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+                    }
+                }
             }
 
             if (argv.maxmaintime || argv.maxmaintimeranked || argv.maxmaintimeunranked) {
@@ -1855,29 +1862,36 @@ class Connection {
                     universalMaintimeForRankedUnrankedSentence = "for unranked games is ";
                 }
                 // now just before TimecontrolString is being tested, we again make sure it has the latest value
-                let universalMaintimeTimecontrolString = String(t.time_control);/*
-                "fischer" , "simple", "byoyomi" , "canadian" , "absolute"*/
-                conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
-                
-                if ((universalMaintimeTimecontrolString === "fischer") && ((t.initial_time > universalMaintimeNumber) || (t.max_time > universalMaintimeNumber))) {
-                    universalMaintimeTimecontrolSentence = "Initial Time and/or Max Time ";
-                    universalMaintimeEndingSentence = ".";
-                }
-                if (universalMaintimeTimecontrolString === "byoyomi" && t.main_time > universalMaintimeNumber) {
-                    universalMaintimeTimecontrolSentence = "Main Time ";
-                    universalMaintimeEndingSentence = ".";
-                }
-                if (universalMaintimeTimecontrolString === "canadian" && t.main_time > universalMaintimeNumber) {
-                    universalMaintimeTimecontrolSentence = "Main Time ";
-                    universalMaintimeEndingSentence = ".";
-                }
+                universalMaintimeTimecontrolString = String(t.time_control);/*
+                "fischer", "byoyomi", "canadian" */
+
                 // sanity check : if not fischer, not byoyomi, not canadian
                 if ((universalMaintimeTimecontrolString !== "fischer") && (universalMaintimeTimecontrolString !== "byoyomi") && (universalMaintimeTimecontrolString !== "canadian")) {
                     conn_log ("error, could not find time control in " + t.time_control);
                     return { reject : true, msg: "error, could not find time control in " + t.timecontrol};
-                }
+                }                
+
                 // if sanity check passes :
-                return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+                if ((universalMaintimeTimecontrolString === "fischer") || (universalMaintimeTimecontrolString === "byoyomi") || (universalMaintimeTimecontrolString === "canadian")) {
+                    if ((universalMaintimeTimecontrolString === "fischer") && ((t.initial_time > universalMaintimeNumber) || (t.max_time > universalMaintimeNumber))) {
+                        universalMaintimeTimecontrolSentence = "Initial Time and/or Max Time ";
+                        universalMaintimeEndingSentence = ".";
+                        conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
+                        return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+                    }
+                    if (universalMaintimeTimecontrolString === "byoyomi" && t.main_time > universalMaintimeNumber) {
+                        universalMaintimeTimecontrolSentence = "Main Time ";
+                        universalMaintimeEndingSentence = ".";
+                        conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
+                        return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+                    }
+                    if (universalMaintimeTimecontrolString === "canadian" && t.main_time > universalMaintimeNumber) {
+                        universalMaintimeTimecontrolSentence = "Main Time ";
+                        universalMaintimeEndingSentence = ".";
+                        conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
+                        return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+                    } 
+                }
             }
         }
 

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -418,48 +418,76 @@ process.on('uncaughtException', function (er) {
   }
 })
 
-if (argv.botid) {
-    console.log("Warning: --botid alias is no longer supported. Use --username instead.");
+// console warnings : for bot admins usage
+
+if (argv.maxhandicap && (argv.maxhandicapranked || argv.maxhandicapunranked)) {
+    console.log("Warning: You are using --maxhandicap in combination with --maxhandicapranked or/and --maxhandicapunranked. \n Use either --maxhandicap alone , OR --maxhandicapranked with --maxhandicapunranked. \n But don't use the 3 --maxhandicap arguments at the same time. " );
 }
 
-if (argv.bot) {
-    console.log("Warning: --bot alias is no longer supported. Use --username instead.");
-}
-
-if (argv.id) {
-    console.log("Warning: --id alias is no longer supported. Use --username instead.");
+if (argv.minhandicap && (argv.minhandicapranked || argv.minhandicapunranked)) {
+    console.log("Warning: You are using --minhandicap in combination with --minhandicapranked or/and --minhandicapunranked. \n Use either --minhandicap alone , OR --minhandicapranked with --minhandicapunranked. \n But don't use the 3 --minhandicap arguments at the same time. " );
 }
 
 if (argv.maxmaintime && (argv.maxmaintimeranked || argv.maxmaintimeunranked)) {
-    console.log("Warning: You are using --maxmaintime in combination with --maxmaintimeranked or/and --maxmaintimeunranked. \n Use either --maxmaintime alone , OR --maxmaintimeranked with --maxmaintimeunranked. \n But don't use the 3 --maxmaintime arguments at the same time. ");
+    console.log("Warning: You are using --maxmaintime in combination with --maxmaintimeranked or/and --maxmaintimeunranked. \n Use either --maxmaintime alone , OR --maxmaintimeranked with --maxmaintimeunranked. \n But don't use the 3 --maxmaintime arguments at the same time. " );
 }
 
 if (argv.minmaintime && (argv.minmaintimeranked || argv.minmaintimeunranked)) {
-    console.log("Warning: You are using --minmaintime in combination with --minmaintimeranked or/and --minmaintimeunranked. \n Use either --minmaintime alone , OR --minmaintimeranked with --minmaintimeunranked. \n But don't use the 3 --minmaintime arguments at the same time. ");
+    console.log("Warning: You are using --minmaintime in combination with --minmaintimeranked or/and --minmaintimeunranked. \n Use either --minmaintime alone , OR --minmaintimeranked with --minmaintimeunranked. \n But don't use the 3 --minmaintime arguments at the same time. " );
+}
+
+if (argv.maxperiods && (argv.maxperiodsranked || argv.maxperiodsunranked)) {
+    console.log("Warning: You are using --maxperiods in combination with --maxperiodsranked or/and --maxperiodsunranked. \n Use either --maxperiods alone , OR --maxperiodsranked with --maxperiodsunranked. \n But don't use the 3 --maxperiods arguments at the same time. " );
+}
+
+if (argv.minperiods && (argv.minperiodsranked || argv.minperiodsunranked)) {
+    console.log("Warning: You are using --minperiods in combination with --minperiodsranked or/and --minperiodsunranked. \n Use either --minperiods alone , OR --minperiodsranked with --minperiodsunranked. \n But don't use the 3 --minperiods arguments at the same time. " );
 }
 
 if (argv.maxperiodtime && (argv.maxperiodtimeranked || argv.maxperiodtimeunranked)) {
-    console.log("Warning: You are using --maxperiodtime in combination with --maxperiodtimeranked or/and --maxperiodtimeunranked. \n Use either --maxperiodtime alone , OR --maxperiodtimeranked with --maxperiodtimeunranked. \n But don't use the 3 --maxperiodtime arguments at the same time. ");
+    console.log("Warning: You are using --maxperiodtime in combination with --maxperiodtimeranked or/and --maxperiodtimeunranked. \n Use either --maxperiodtime alone , OR --maxperiodtimeranked with --maxperiodtimeunranked. \n But don't use the 3 --maxperiodtime arguments at the same time. " );
 }
 
 if (argv.minperiodtime && (argv.minperiodtimeranked || argv.minperiodtimeunranked)) {
-    console.log("Warning: You are using --minperiodtime in combination with --minperiodtimeranked or/and --minperiodtimeunranked. \n Use either --minperiodtime alone , OR --minperiodtimeranked with --minperiodtimeunranked. \n But don't use the 3 --minperiodtime arguments at the same time. ");
+    console.log("Warning: You are using --minperiodtime in combination with --minperiodtimeranked or/and --minperiodtimeunranked. \n Use either --minperiodtime alone , OR --minperiodtimeranked with --minperiodtimeunranked. \n But don't use the 3 --minperiodtime arguments at the same time. " );
+}
+
+if (argv.noautohandicap && (argv.noautohandicapranked || argv.noautohandicapunranked)) {
+    console.log("Warning: You are using --noautohandicap in combination with --noautohandicapranked or/and --noautohandicapunranked. \n Use either --noautohandicap alone , OR --noautohandicapranked with --noautohandicapunranked. \n But don't use the 3 --noautohandicap arguments at the same time. " );
+}
+
+if (argv.nopause && (argv.nopauseranked || argv.nopauseunranked)) {
+    console.log("Warning: You are using --nopause in combination with --nopauseranked or/and --nopauseunranked. \n Use either --nopause alone , OR --nopauseranked with --nopauseunranked. \n But don't use the 3 --nopause arguments at the same time. " );
+}
+
+// console warnings : depreciated features if used
+
+if (argv.botid) {
+    console.log("Warning: --botid alias is no longer supported. Use --username instead." );
+}
+
+if (argv.bot) {
+    console.log("Warning: --bot alias is no longer supported. Use --username instead." );
+}
+
+if (argv.id) {
+    console.log("Warning: --id alias is no longer supported. Use --username instead." );
 }
 
 if (argv.minrankedhandicap) {
-    console.log("Warning: --minrankedhandicap argument is no longer supported. Use --minhandicapranked instead.");
+    console.log("Warning: --minrankedhandicap argument is no longer supported. Use --minhandicapranked instead." );
 }
 
 if (argv.maxrankedhandicap) {
-    console.log("Warning: --minrankedhandicap argument is no longer supported. Use --maxhandicapranked instead.");
+    console.log("Warning: --minrankedhandicap argument is no longer supported. Use --maxhandicapranked instead." );
 }
 
 if (argv.minunrankedhandicap) {
-    console.log("Warning: --minrankedhandicap argument is no longer supported. Use --minhandicapunranked instead.");
+    console.log("Warning: --minrankedhandicap argument is no longer supported. Use --minhandicapunranked instead." );
 }
 
 if (argv.maxunrankedhandicap) {
-    console.log("Warning: --minrankedhandicap argument is no longer supported. Use --maxhandicapunranked instead.");
+    console.log("Warning: --minrankedhandicap argument is no longer supported. Use --maxhandicapunranked instead." );
 }
 
 
@@ -1275,7 +1303,7 @@ class Game {
         return sprintf("%s %s  [%ix%i]  %s", color, name, this.state.width, this.state.width, handi);
 
         // XXX doesn't work, getting garbage ranks here ...
-        // let rank = rank2str(player.rank);
+        // let rank = rankToString(player.rank);
     } /* }}} */
     log(str) { /* {{{ */
         let moves = (this.state && this.state.moves ? this.state.moves.length : 0);
@@ -1614,15 +1642,15 @@ class Connection {
         }
 
         if (user.ranking < argv.minrank) {
-            let humanReadableUserRank = rank2str(user.ranking);
-            let humanReadableMinRank = rank2str(argv.minrank);
+            let humanReadableUserRank = rankToString(user.ranking);
+            let humanReadableMinRank = rankToString(argv.minrank);
             conn_log(user.username + " ranking too low: " + humanReadableUserRank + " : min is " + humanReadableMinRank);
             return { reject: true, msg: "Minimum rank is " + humanReadableMinRank + " , your rank is too low, try again when your rank is high enough." };
         }
 
         if (user.ranking > argv.maxrank) {
-            let humanReadableUserRank = rank2str(user.ranking);
-            let humanReadableMaxRank = rank2str(argv.maxrank);
+            let humanReadableUserRank = rankToString(user.ranking);
+            let humanReadableMaxRank = rankToString(argv.maxrank);
             conn_log(user.username + " ranking too high: " + humanReadableUserRank + " : max is " + humanReadableMaxRank);
             return { reject: true, msg: "Maximum rank is " + humanReadableMaxRank + " , your rank is too high, try again when your rank is low enough." };
         }
@@ -1640,19 +1668,6 @@ class Connection {
         if (["chinese"].indexOf(notification.rules) < 0) {
             conn_log("Unhandled rules: " + notification.rules + ", rejecting challenge");
             return { reject: true, msg: "The " + notification.rules + " rules are not allowed for this bot, please choose allowed rules such as chinese rules. " };
-        }
-        
-        
-        function timespanToDisplayString(timespan) {
-            let ss = timespan % 60;
-            let mm = Math.floor(timespan / 60 % 60);
-            let hh = Math.floor(timespan / (60*60) % 24);
-            let dd = Math.floor(timespan / (60*60*24));
-            let text = ["days", "hours", "minutes", "seconds"];
-            return [dd, hh, mm, ss]
-                .map((e, i) => e === 0 ? "" : `${e} ${text[i]}`)
-                .filter(e => e !== "")
-                .join(" ");
         }
     
         if (argv.rankedonly && !notification.ranked) {
@@ -1747,95 +1762,126 @@ class Connection {
             return { reject: true, msg: "The " + t.time_control + " time control is not allowed, please choose one of these allowed time controls : " + argv.timecontrol };
         }
 
-        if (argv.minmaintime) {
-            if ( ["simple","none"].indexOf(t.time_control) >= 0) {
-                conn_log("Minimum main time not supported in time control: " + t.time_control);
-                return { reject: true, msg: "Minimum main time is not supported in the time control " + t.time_control + ", please choose a time control that supports the use of a minimum main time, such as byoyomi,fischer,canadian." };
+        ////// begining of *** UHMAEAT : Universal Highly Modulable And Expandable Argv Tree ***
+
+        if (argv.minmaintime || argv.minmaintimeranked || argv.minmaintimeunranked || argv.maxmaintime || argv.maxmaintimeranked || argv.maxmaintimeunranked) {
+            // later the t.time_control can't be used for rule detection for some reason,
+            // so storing it now in a string while we can
+            // also, whenever before TimecontrolString is going to be tested,
+            // we always make sure it has the latest value
+            // this avoids TimecontrolString being frozen on the same value independently from what user chooses, 
+            // e.g. stuck on "absolute"
+            // ** first we eliminate absolute and simple time control : they don't support the use of a period time
+            // using absolute or simple (no period time) is likely to make bots timeout or play way too fast
+            let universalMaintimeTimecontrolString = String(t.time_control);/*
+            "fischer" , "simple", "byoyomi" , "canadian" , "absolute"*/
+            if ((universalMaintimeTimecontrolString === "absolute") || (universalMaintimeTimecontrolString === "simple")) {
+                conn_log(`Minimum and Maximum main time is not supported in time control: ${universalMaintimeTimecontrolString}` );
+                return { reject: true, msg: `Period time management is not supported in the time control ${universalMaintimeTimecontrolString} , please choose a time control that supports the use of a period time, such as byoyomi,fischer,canadian.`};
+            }          
+
+            // ** then for fischer, byoyomi, or canadian, we use our UHMAEAT !
+            let universalMaintimeMinimumMaximumSentence = "";    // minimum
+            let universalMaintimeTimecontrolSentence = "";       // main time - initial time and/or max time, etc..
+            let universalMaintimeForRankedUnrankedSentence = ""; // +/- for ranked/unranked games is
+            let universalMaintimeNumber = 0;                     // for example 600 (600 seconds)
+            let universalMaintimeToString = "";                  // for example "10 minutes"  = timespanToDisplayString(argv.xxx)
+            let universalMaintimeIncreaseDecreaseSentence = "";  // , please increase/decrease
+                                                                 // main time - MaintimeTimecontrolSentence again
+            let universalMaintimeEndingSentence = "";            // optionnal, for example in canadian, adds explanation
+
+            if (argv.minmaintime || argv.minmaintimeranked || argv.minmaintimeunranked) {
+                universalMaintimeMinimumMaximumSentence = "Minimum ";
+                universalMaintimeIncreaseDecreaseSentence = ", please increase ";
+                let universalMaintimeConnSentence = user.username + " wanted main time below minimum main time ";
+                if (argv.minmaintime) {
+                    universalMaintimeNumber = argv.minmaintime;
+                    universalMaintimeToString = timespanToDisplayString(argv.minmaintime);
+                    universalMaintimeForRankedUnrankedSentence = "is ";
+                }
+                if (argv.minmaintimeranked && notification.ranked) {
+                    universalMaintimeNumber = argv.minmaintimeranked;
+                    universalMaintimeToString = timespanToDisplayString(argv.minmaintimeranked);
+                    universalMaintimeForRankedUnrankedSentence = "for ranked games is ";
+                }
+                if (argv.minmaintimeunranked && !notification.ranked) {
+                    universalMaintimeNumber = argv.minmaintimeunranked;
+                    universalMaintimeToString = timespanToDisplayString(argv.minmaintimeunranked);
+                    universalMaintimeForRankedUnrankedSentence = "for unranked games is ";
+                 }
+                // now just before TimecontrolString is being tested, we again make sure it has the latest value
+                universalMaintimeTimecontrolString = String(t.time_control);/*
+                "fischer", "byoyomi", "canadian" */
+                conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
+                if ((universalMaintimeTimecontrolString === "fischer") && ((t.initial_time < universalMaintimeNumber) || (t.max_time < universalMaintimeNumber))) {
+                    universalMaintimeTimecontrolSentence = "Initial Time and/or Max Time ";
+                    universalMaintimeEndingSentence = ".";
+                }
+                if (universalMaintimeTimecontrolString === "byoyomi" && t.main_time < universalMaintimeNumber) {
+                    universalMaintimeTimecontrolSentence = "Main Time ";
+                    universalMaintimeEndingSentence = ".";
+                }
+                if (universalMaintimeTimecontrolString === "canadian" && t.main_time < universalMaintimeNumber) {
+                    universalMaintimeTimecontrolSentence = "Main Time ";
+                    universalMaintimeEndingSentence = "."; 
+                }
+                // sanity check : if not fischer, not byoyomi, not canadian
+                if ((universalMaintimeTimecontrolString !== "fischer") && (universalMaintimeTimecontrolString !== "byoyomi") && (universalMaintimeTimecontrolString !== "canadian")) {
+                    conn_log ("error, could not find time control in " + t.time_control);
+                    return { reject : true, msg: "error, could not find time control in " + t.timecontrol};
+                }
+                // if sanity check passes :
+                return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
+
             }
-            if (t.total_time   < argv.minmaintime  || // absolute
-                t.initial_time < argv.minmaintime  || // fischer
-                t.max_time     < argv.minmaintime  || // fischer
-                t.main_time    < argv.minmaintime) {  // others
-                    let humanReadableTime = timespanToDisplayString(argv.minmaintime);
-                    conn_log(user.username + " wanted main time below minmaintime " + humanReadableTime);
-                    return { reject: true, msg: "Minimum main time is " + humanReadableTime + ", please increase main time \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
+
+            if (argv.maxmaintime || argv.maxmaintimeranked || argv.maxmaintimeunranked) {
+                universalMaintimeMinimumMaximumSentence = "Maximum ";
+                universalMaintimeIncreaseDecreaseSentence = ", please reduce ";
+                let universalMaintimeConnSentence = user.username + " wanted main time above maximum main time ";
+                if (argv.maxmaintime) {
+                    universalMaintimeNumber = argv.maxmaintime;
+                    universalMaintimeToString = timespanToDisplayString(argv.maxmaintime);
+                    universalMaintimeForRankedUnrankedSentence = "is ";
+                }
+                if (argv.maxmaintimeranked && notification.ranked) {
+                    universalMaintimeNumber = argv.maxmaintimeranked;
+                    universalMaintimeToString = timespanToDisplayString(argv.maxmaintimeranked);
+                    universalMaintimeForRankedUnrankedSentence = "for ranked games is ";
+                }
+                if (argv.maxmaintimeunranked && !notification.ranked) {
+                    universalMaintimeNumber = argv.maxmaintimeunranked;
+                    universalMaintimeToString = timespanToDisplayString(argv.maxmaintimeunranked);
+                    universalMaintimeForRankedUnrankedSentence = "for unranked games is ";
+                }
+                // now just before TimecontrolString is being tested, we again make sure it has the latest value
+                let universalMaintimeTimecontrolString = String(t.time_control);/*
+                "fischer" , "simple", "byoyomi" , "canadian" , "absolute"*/
+                conn_log(universalMaintimeConnSentence + universalMaintimeToString + " in " + universalMaintimeTimecontrolString);
+                
+                if ((universalMaintimeTimecontrolString === "fischer") && ((t.initial_time > universalMaintimeNumber) || (t.max_time > universalMaintimeNumber))) {
+                    universalMaintimeTimecontrolSentence = "Initial Time and/or Max Time ";
+                    universalMaintimeEndingSentence = ".";
+                }
+                if (universalMaintimeTimecontrolString === "byoyomi" && t.main_time > universalMaintimeNumber) {
+                    universalMaintimeTimecontrolSentence = "Main Time ";
+                    universalMaintimeEndingSentence = ".";
+                }
+                if (universalMaintimeTimecontrolString === "canadian" && t.main_time > universalMaintimeNumber) {
+                    universalMaintimeTimecontrolSentence = "Main Time ";
+                    universalMaintimeEndingSentence = ".";
+                }
+                // sanity check : if not fischer, not byoyomi, not canadian
+                if ((universalMaintimeTimecontrolString !== "fischer") && (universalMaintimeTimecontrolString !== "byoyomi") && (universalMaintimeTimecontrolString !== "canadian")) {
+                    conn_log ("error, could not find time control in " + t.time_control);
+                    return { reject : true, msg: "error, could not find time control in " + t.timecontrol};
+                }
+                // if sanity check passes :
+                return { reject : true, msg:  `${universalMaintimeMinimumMaximumSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeForRankedUnrankedSentence} ${universalMaintimeToString} ${universalMaintimeIncreaseDecreaseSentence} ${universalMaintimeTimecontrolSentence} ${universalMaintimeEndingSentence}` };
             }
         }
 
-        if (argv.maxmaintime) {
-            if (["simple","none"].indexOf(t.time_control) >= 0) {
-                conn_log("Maximum main time not supported in time control: " + t.time_control);
-                return { reject: true, msg: "Maximum main time not supported in time control " + t.time_control + ", please choose a time control that supports the use of a minimum main time, such as byoyomi,fischer,canadian. " };
-            }
-            if (t.total_time   > argv.maxmaintime  || // absolute
-                t.initial_time > argv.maxmaintime  || // fischer
-                t.max_time     > argv.maxmaintime  || // fischer
-                t.main_time    > argv.maxmaintime) {  // others
-                    let humanReadableTime = timespanToDisplayString(argv.maxmaintime);
-                    conn_log(user.username + " wanted main time above maxmaintime " + humanReadableTime);
-                    return { reject: true, msg: "Maximum main time is " + humanReadableTime + ", please reduce main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
-            }
-        }
-
-        if (argv.minmaintimeranked && notification.ranked) {
-            if ( ["simple","none"].indexOf(t.time_control) >= 0) {
-                conn_log("Minimum main time not supported in time control: " + t.time_control);
-                return { reject: true, msg: "Minimum main time is not supported in the time control " + t.time_control + ", please choose a time control that supports the use of a minimum main time, such as byoyomi,fischer,canadian." };
-            }
-            if (t.total_time   < argv.minmaintimeranked  || // absolute
-                t.initial_time < argv.minmaintimeranked  || // fischer
-                t.max_time     < argv.minmaintimeranked  || // fischer
-                t.main_time    < argv.minmaintimeranked) {  // others
-                    let humanReadableTime = timespanToDisplayString(argv.minmaintimeranked);
-                    conn_log(user.username + " wanted main time ranked below minmaintimeranked " + humanReadableTime);
-                    return { reject: true, msg: "Minimum main time for ranked games is " + humanReadableTime + ", please increase main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
-            }
-        }
-
-        if (argv.maxmaintimeranked && notification.ranked) {
-            if (["simple","none"].indexOf(t.time_control) >= 0) {
-                conn_log("Maximum main time not supported in time control: " + t.time_control);
-                return { reject: true, msg: "Maximum main time not supported in time control " + t.time_control + ", please choose a time control that supports the use of a minimum main time, such as byoyomi,fischer,canadian. " };
-            }
-            if (t.total_time   > argv.maxmaintimeranked  || // absolute
-                t.initial_time > argv.maxmaintimeranked  || // fischer
-                t.max_time     > argv.maxmaintimeranked  || // fischer
-                t.main_time    > argv.maxmaintimeranked) {  // others
-                    let humanReadableTime = timespanToDisplayString(argv.maxmaintimeranked);
-                    conn_log(user.username + " wanted main time ranked above maxmaintimeranked " + humanReadableTime);
-                    return { reject: true, msg: "Maximum main time for ranked games is " + humanReadableTime + ", please reduce main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
-            }
-        }
-
-        if (argv.minmaintimeunranked && !notification.ranked) {
-            if ( ["simple","none"].indexOf(t.time_control) >= 0) {
-                conn_log("Minimum main time not supported in time control: " + t.time_control);
-                return { reject: true, msg: "Minimum main time is not supported in the time control " + t.time_control + ", please choose a time control that supports the use of a minimum main time, such as byoyomi,fischer,canadian." };
-            }
-            if (t.total_time   < argv.minmaintimeunranked  || // absolute
-                t.initial_time < argv.minmaintimeunranked  || // fischer
-                t.max_time     < argv.minmaintimeunranked  || // fischer
-                t.main_time    < argv.minmaintimeunranked) {  // others
-                    let humanReadableTime = timespanToDisplayString(argv.minmaintimeunranked);
-                    conn_log(user.username + " wanted main time unranked below minmaintimeunranked " + humanReadableTime);
-                    return { reject: true, msg: "Minimum main time for unranked games is " + humanReadableTime + ", please increase main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
-            }
-        }
-
-        if (argv.maxmaintimeunranked && !notification.ranked) {
-            if (["simple","none"].indexOf(t.time_control) >= 0) {
-                conn_log("Maximum main time not supported in time control: " + t.time_control);
-                return { reject: true, msg: "Maximum main time not supported in time control " + t.time_control + ", please choose a time control that supports the use of a minimum main time, such as byoyomi,fischer,canadian. " };
-            }
-            if (t.total_time   > argv.maxmaintimeunranked  || // absolute
-                t.initial_time > argv.maxmaintimeunranked  || // fischer
-                t.max_time     > argv.maxmaintimeunranked  || // fischer
-                t.main_time    > argv.maxmaintimeunranked) {  // others
-                    let humanReadableTime = timespanToDisplayString(argv.maxmaintimeunranked);
-                    conn_log(user.username + " wanted main time unranked above maxmaintimeunranked " + humanReadableTime);
-                    return { reject: true, msg: "Maximum main time for unranked games is " + humanReadableTime + ", please reduce main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
-            }
-        }
+        ////// end of *** UHMAEAT : Universal Highly Modulable And Expandable Argv Tree ***
 
         if (argv.minperiods && (t.periods < argv.minperiods)) {
             conn_log(user.username + " wanted too few periods: " + t.periods);
@@ -1968,7 +2014,7 @@ class Connection {
         let handi = (notification.handicap > 0 ? "H" + notification.handicap : "");
         let accepting = (c.reject ? "Rejecting" : "Accepting");
         conn_log(sprintf("%s challenge from %s (%s)  [%ix%i] %s id = %i",
-                         accepting, notification.user.username, rank2str(notification.user.ranking),
+                         accepting, notification.user.username, rankToString(notification.user.ranking),
                          notification.width, notification.width,
                          handi, notification.game_id));
 
@@ -2247,10 +2293,21 @@ function num2gtpchar(num) { /* {{{ */
         return ".";
     return "abcdefghjklmnopqrstuvwxyz"[num];
 } /* }}} */
-function rank2str(r) { /* {{{ */
+function rankToString(r) { /* {{{ */
     r = Math.floor(r);
     if (r >= 30)  return (r-30+1) + 'd'; // r>=30 : 1 dan or stronger
     else          return (30-r) + 'k'; // r<30 : 1 kyu or weaker
+} /* }}} */
+function timespanToDisplayString(timespan) {
+    let ss = timespan % 60;
+    let mm = Math.floor(timespan / 60 % 60);
+    let hh = Math.floor(timespan / (60*60) % 24);
+    let dd = Math.floor(timespan / (60*60*24));
+    let text = ["days", "hours", "minutes", "seconds"];
+    return [dd, hh, mm, ss]
+    .map((e, i) => e === 0 ? "" : `${e} ${text[i]}`)
+    .filter(e => e !== "")
+    .join(" ");
 } /* }}} */
 
 function conn_log() { /* {{{ */

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -430,6 +430,22 @@ if (argv.id) {
     console.log("Warning: --id alias is no longer supported. Use --username instead.");
 }
 
+if (argv.maxmaintime && (argv.maxmaintimeranked || argv.maxmaintimeunranked)) {
+    console.log("Warning: You are using --maxmaintime in combination with --maxmaintimeranked or/and --maxmaintimeunranked. \n Use either --maxmaintime alone , OR --maxmaintimeranked with --maxmaintimeunranked. \n But don't use the 3 --maxmaintime arguments at the same time. ");
+}
+
+if (argv.minmaintime && (argv.minmaintimeranked || argv.minmaintimeunranked)) {
+    console.log("Warning: You are using --minmaintime in combination with --minmaintimeranked or/and --minmaintimeunranked. \n Use either --minmaintime alone , OR --minmaintimeranked with --minmaintimeunranked. \n But don't use the 3 --minmaintime arguments at the same time. ");
+}
+
+if (argv.maxperiodtime && (argv.maxperiodtimeranked || argv.maxperiodtimeunranked)) {
+    console.log("Warning: You are using --maxperiodtime in combination with --maxperiodtimeranked or/and --maxperiodtimeunranked. \n Use either --maxperiodtime alone , OR --maxperiodtimeranked with --maxperiodtimeunranked. \n But don't use the 3 --maxperiodtime arguments at the same time. ");
+}
+
+if (argv.minperiodtime && (argv.minperiodtimeranked || argv.minperiodtimeunranked)) {
+    console.log("Warning: You are using --minperiodtime in combination with --minperiodtimeranked or/and --minperiodtimeunranked. \n Use either --minperiodtime alone , OR --minperiodtimeranked with --minperiodtimeunranked. \n But don't use the 3 --minperiodtime arguments at the same time. ");
+}
+
 if (argv.minrankedhandicap) {
     console.log("Warning: --minrankedhandicap argument is no longer supported. Use --minhandicapranked instead.");
 }
@@ -445,6 +461,8 @@ if (argv.minunrankedhandicap) {
 if (argv.maxunrankedhandicap) {
     console.log("Warning: --minrankedhandicap argument is no longer supported. Use --maxhandicapunranked instead.");
 }
+
+
 
 /*********/
 /** Bot **/
@@ -1596,13 +1614,17 @@ class Connection {
         }
 
         if (user.ranking < argv.minrank) {
-            conn_log(user.username + " ranking too low: " + user.ranking);
-            return { reject: true, msg: "Minimum rank allowed is " + argv.minrank + " (in bot ranking units), your rank is " + user.ranking + " (in bot ranking units), your rank is too low, try again when your rank is high enough." };
+            let humanReadableUserRank = rank2str(user.ranking);
+            let humanReadableMinRank = rank2str(argv.minrank);
+            conn_log(user.username + " ranking too low: " + humanReadableUserRank + " : min is " + humanReadableMinRank);
+            return { reject: true, msg: "Minimum rank is " + humanReadableMinRank + " , your rank is too low, try again when your rank is high enough." };
         }
 
         if (user.ranking > argv.maxrank) {
-            conn_log(user.username + " ranking too high: " + user.ranking);
-            return { reject: true, msg: "Maximum rank allowed is " + argv.maxrank + " (in bot ranking units), your rank is " + user.ranking + " (in bot ranking units), your rank is too high, try again when your rank is low enough." };
+            let humanReadableUserRank = rank2str(user.ranking);
+            let humanReadableMaxRank = rank2str(argv.maxrank);
+            conn_log(user.username + " ranking too high: " + humanReadableUserRank + " : max is " + humanReadableMaxRank);
+            return { reject: true, msg: "Maximum rank is " + humanReadableMaxRank + " , your rank is too high, try again when your rank is low enough." };
         }
 
         return { reject: false }; // OK !
@@ -1734,9 +1756,9 @@ class Connection {
                 t.initial_time < argv.minmaintime  || // fischer
                 t.max_time     < argv.minmaintime  || // fischer
                 t.main_time    < argv.minmaintime) {  // others
-                    let botSecondsTime = timespanToDisplayString(argv.minmaintime);
-                    conn_log(user.username + " wanted main time below minmaintime " + botSecondsTime);
-                    return { reject: true, msg: "Minimum main time is " + botSecondsTime + ", please increase main time \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
+                    let humanReadableTime = timespanToDisplayString(argv.minmaintime);
+                    conn_log(user.username + " wanted main time below minmaintime " + humanReadableTime);
+                    return { reject: true, msg: "Minimum main time is " + humanReadableTime + ", please increase main time \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
             }
         }
 
@@ -1749,9 +1771,9 @@ class Connection {
                 t.initial_time > argv.maxmaintime  || // fischer
                 t.max_time     > argv.maxmaintime  || // fischer
                 t.main_time    > argv.maxmaintime) {  // others
-                    let botSecondsTime = timespanToDisplayString(argv.maxmaintime);
-                    conn_log(user.username + " wanted main time above maxmaintime " + botSecondsTime);
-                    return { reject: true, msg: "Maximum main time is " + botSecondsTime + ", please reduce main time. \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
+                    let humanReadableTime = timespanToDisplayString(argv.maxmaintime);
+                    conn_log(user.username + " wanted main time above maxmaintime " + humanReadableTime);
+                    return { reject: true, msg: "Maximum main time is " + humanReadableTime + ", please reduce main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
             }
         }
 
@@ -1764,9 +1786,9 @@ class Connection {
                 t.initial_time < argv.minmaintimeranked  || // fischer
                 t.max_time     < argv.minmaintimeranked  || // fischer
                 t.main_time    < argv.minmaintimeranked) {  // others
-                    let botSecondsTime = timespanToDisplayString(argv.minmaintimeranked);
-                    conn_log(user.username + " wanted main time ranked below minmaintimeranked " + botSecondsTime);
-                    return { reject: true, msg: "Minimum main time for ranked games is " + botSecondsTime + ", please increase main time. \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
+                    let humanReadableTime = timespanToDisplayString(argv.minmaintimeranked);
+                    conn_log(user.username + " wanted main time ranked below minmaintimeranked " + humanReadableTime);
+                    return { reject: true, msg: "Minimum main time for ranked games is " + humanReadableTime + ", please increase main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
             }
         }
 
@@ -1779,9 +1801,9 @@ class Connection {
                 t.initial_time > argv.maxmaintimeranked  || // fischer
                 t.max_time     > argv.maxmaintimeranked  || // fischer
                 t.main_time    > argv.maxmaintimeranked) {  // others
-                    let botSecondsTime = timespanToDisplayString(argv.maxmaintimeranked);
-                    conn_log(user.username + " wanted main time ranked above maxmaintimeranked " + botSecondsTime);
-                    return { reject: true, msg: "Maximum main time for ranked games is " + botSecondsTime + ", please reduce main time. \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
+                    let humanReadableTime = timespanToDisplayString(argv.maxmaintimeranked);
+                    conn_log(user.username + " wanted main time ranked above maxmaintimeranked " + humanReadableTime);
+                    return { reject: true, msg: "Maximum main time for ranked games is " + humanReadableTime + ", please reduce main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
             }
         }
 
@@ -1794,9 +1816,9 @@ class Connection {
                 t.initial_time < argv.minmaintimeunranked  || // fischer
                 t.max_time     < argv.minmaintimeunranked  || // fischer
                 t.main_time    < argv.minmaintimeunranked) {  // others
-                    let botSecondsTime = timespanToDisplayString(argv.minmaintimeunranked);
-                    conn_log(user.username + " wanted main time unranked below minmaintimeunranked " + botSecondsTime);
-                    return { reject: true, msg: "Minimum main time for unranked games is " + botSecondsTime + ", please increase main time. \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
+                    let humanReadableTime = timespanToDisplayString(argv.minmaintimeunranked);
+                    conn_log(user.username + " wanted main time unranked below minmaintimeunranked " + humanReadableTime);
+                    return { reject: true, msg: "Minimum main time for unranked games is " + humanReadableTime + ", please increase main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
             }
         }
 
@@ -1809,9 +1831,9 @@ class Connection {
                 t.initial_time > argv.maxmaintimeunranked  || // fischer
                 t.max_time     > argv.maxmaintimeunranked  || // fischer
                 t.main_time    > argv.maxmaintimeunranked) {  // others
-                    let botSecondsTime = timespanToDisplayString(argv.maxmaintimeunranked);
-                    conn_log(user.username + " wanted main time unranked above maxmaintimeunranked " + botSecondsTime);
-                    return { reject: true, msg: "Maximum main time for unranked games is " + botSecondsTime + ", please reduce main time. \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
+                    let humanReadableTime = timespanToDisplayString(argv.maxmaintimeunranked);
+                    conn_log(user.username + " wanted main time unranked above maxmaintimeunranked " + humanReadableTime);
+                    return { reject: true, msg: "Maximum main time for unranked games is " + humanReadableTime + ", please reduce main time. \n - If you use Fischer, you need to change both -initial time- and -max time-, and also -time increment- \n - If you use canadian byo-yomi, set the average time per stone, for example 5 minutes/25 stones needs to be set up as 180 seconds (5 minutes) divided by 25 stones , which equals 7.2 seconds per stone. " };
             }
         }
 
@@ -1852,9 +1874,9 @@ class Connection {
                 || ((t.period_time / t.stones_per_period) < argv.minperiodtime)
             ))
         {
-            let botSecondsTime = timespanToDisplayString(argv.minperiodtime);
+            let humanReadableTime = timespanToDisplayString(argv.minperiodtime);
             conn_log(user.username + " wanted period time too short");
-            return { reject: true, msg: "Minimum is " + botSecondsTime + " per period, please increase period time " };
+            return { reject: true, msg: "Minimum is " + humanReadableTime + " per period, please increase period time. \n - If you use Fischer, you need to change -increment time- " };
         }
 
         if (argv.maxperiodtime &&
@@ -1864,9 +1886,9 @@ class Connection {
                 || ((t.period_time / t.stones_per_period) > argv.maxperiodtime)
             ))
         {
-            let botSecondsTime = timespanToDisplayString(argv.maxperiodtime);
+            let humanReadableTime = timespanToDisplayString(argv.maxperiodtime);
             conn_log(user.username + " wanted period time too long");
-            return { reject: true, msg: "Maximum is " + botSecondsTime + " per period, please reduce period time " };
+            return { reject: true, msg: "Maximum is " + humanReadableTime + " per period, please reduce period time \n - If you use Fischer, you need to change -increment time-" };
         }
 
         if (argv.minperiodtimeranked && notification.ranked && 
@@ -1876,9 +1898,9 @@ class Connection {
                 || ((t.period_time / t.stones_per_period) < argv.minperiodtimeranked)
             ))
         {
-            let botSecondsTime = timespanToDisplayString(argv.minperiodtimeranked);
+            let humanReadableTime = timespanToDisplayString(argv.minperiodtimeranked);
             conn_log(user.username + " wanted period time ranked too short");
-            return { reject: true, msg: "Minimum is " + botSecondsTime + " per period for ranked games, please increase period time " };
+            return { reject: true, msg: "Minimum is " + humanReadableTime + " per period for ranked games, please increase period time \n - If you use Fischer, you need to change -increment time- " };
         }
 
         if (argv.maxperiodtimeranked && notification.ranked &&
@@ -1888,9 +1910,9 @@ class Connection {
                 || ((t.period_time / t.stones_per_period) > argv.maxperiodtimeranked)
             ))
         {
-            let botSecondsTime = timespanToDisplayString(argv.maxperiodtimeranked);
+            let humanReadableTime = timespanToDisplayString(argv.maxperiodtimeranked);
             conn_log(user.username + " wanted period time ranked too long");
-            return { reject: true, msg: "Maximum is " + botSecondsTime + " per period for ranked games, please reduce period time " };
+            return { reject: true, msg: "Maximum is " + humanReadableTime + " per period for ranked games, please reduce period time \n - If you use Fischer, you need to change -increment time- " };
         }
 
         if (argv.minperiodtimeunranked && !notification.ranked && 
@@ -1900,9 +1922,9 @@ class Connection {
                 || ((t.period_time / t.stones_per_period) < argv.minperiodtimeunranked)
             ))
         {
-            let botSecondsTime = timespanToDisplayString(argv.minperiodtimeunranked);
+            let humanReadableTime = timespanToDisplayString(argv.minperiodtimeunranked);
             conn_log(user.username + " wanted period time unranked too short");
-            return { reject: true, msg: "Minimum is " + botSecondsTime + " per period for unranked games, please increase period time " };
+            return { reject: true, msg: "Minimum is " + humanReadableTime + " per period for unranked games, please increase period time \n - If you use Fischer, you need to change -increment time- " };
         }
 
         if (argv.maxperiodtimeunranked && !notification.ranked &&
@@ -1912,9 +1934,9 @@ class Connection {
                 || ((t.period_time / t.stones_per_period) > argv.maxperiodtimeunranked)
             ))
         {
-            let botSecondsTime = timespanToDisplayString(argv.maxperiodtimeunranked);
+            let humanReadableTime = timespanToDisplayString(argv.maxperiodtimeunranked);
             conn_log(user.username + " wanted period time unranked too long");
-            return { reject: true, msg: "Maximum is " + botSecondsTime + " seconds per period for unranked games, please reduce period time " };
+            return { reject: true, msg: "Maximum is " + humanReadableTime + " seconds per period for unranked games, please reduce period time \n - If you use Fischer, you need to change -increment time- " };
         }
 
         return { reject: false };  // Ok !
@@ -2226,9 +2248,9 @@ function num2gtpchar(num) { /* {{{ */
     return "abcdefghjklmnopqrstuvwxyz"[num];
 } /* }}} */
 function rank2str(r) { /* {{{ */
-    r = r.toFixed();
-    if (r >= 30)  return (r-30+1) + 'd';
-    else          return (30-r) + 'k';
+    r = Math.floor(r);
+    if (r >= 30)  return (r-30+1) + 'd'; // r>=30 : 1 dan or stronger
+    else          return (30-r) + 'k'; // r<30 : 1 kyu or weaker
 } /* }}} */
 
 function conn_log() { /* {{{ */

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1669,6 +1669,15 @@ class Connection {
             conn_log("Unhandled rules: " + notification.rules + ", rejecting challenge");
             return { reject: true, msg: "The " + notification.rules + " rules are not allowed for this bot, please choose allowed rules such as chinese rules. " };
         }
+
+        // ** first we eliminate absolute and simple time control : they don't support the use of a period time
+        // using absolute or simple (no period time) is likely to make bots timeout or play way too fast 
+        /* "fischer" , "simple", "byoyomi" , "canadian" , "absolute"*/
+        let TimeControlString = String(t.time_control);
+        if ((TimeControlString === "absolute") || (TimeControlString === "simple")) {
+            conn_log("Minimum and Maximum main time is not supported in time control " + TimeControlString);
+            return { reject: true, msg: "Period time management is not supported in the time control " + TimeControlString + " , please choose a time control that supports the use of a period time, such as byoyomi,fischer,canadian." };
+            }          
     
         if (argv.rankedonly && !notification.ranked) {
             conn_log("Ranked games only");
@@ -1770,17 +1779,9 @@ class Connection {
             // also, whenever before TimecontrolString is going to be tested,
             // we always make sure it has the latest value
             // this avoids TimecontrolString being frozen on the same value independently from what user chooses, 
-            // e.g. stuck on "absolute"
-            // ** first we eliminate absolute and simple time control : they don't support the use of a period time
-            // using absolute or simple (no period time) is likely to make bots timeout or play way too fast
-            let universalMaintimeTimecontrolString = String(t.time_control);/*
-            "fischer" , "simple", "byoyomi" , "canadian" , "absolute"*/
-            if ((universalMaintimeTimecontrolString === "absolute") || (universalMaintimeTimecontrolString === "simple")) {
-                conn_log(`Minimum and Maximum main time is not supported in time control: ${universalMaintimeTimecontrolString}` );
-                return { reject: true, msg: `Period time management is not supported in the time control ${universalMaintimeTimecontrolString} , please choose a time control that supports the use of a period time, such as byoyomi,fischer,canadian.`};
-            }          
+            // e.g. stuck on "absolute"  
 
-            // ** then for fischer, byoyomi, or canadian, we use our UHMAEAT !
+            // for fischer, byoyomi, or canadian, we use our UHMAEAT !
             let universalMaintimeMinimumMaximumSentence = "";    // minimum
             let universalMaintimeTimecontrolSentence = "";       // main time - initial time and/or max time, etc..
             let universalMaintimeForRankedUnrankedSentence = ""; // +/- for ranked/unranked games is
@@ -1789,6 +1790,8 @@ class Connection {
             let universalMaintimeIncreaseDecreaseSentence = "";  // , please increase/decrease
                                                                  // main time - MaintimeTimecontrolSentence again
             let universalMaintimeEndingSentence = "";            // optionnal, for example in canadian, adds explanation
+            let universalMaintimeTimecontrolString = String(t.time_control);/*
+            "fischer" , "simple", "byoyomi" , "canadian" , "absolute"*/
 
             if (argv.minmaintime || argv.minmaintimeranked || argv.minmaintimeunranked) {
                 universalMaintimeMinimumMaximumSentence = "Minimum ";

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -464,6 +464,14 @@ if (argv.nopause && (argv.nopauseranked || argv.nopauseunranked)) {
     console.log("Warning: You are using --nopause in combination with --nopauseranked or/and --nopauseunranked. \n Use either --nopause alone , OR --nopauseranked with --nopauseunranked. \n But don't use the 3 --nopause arguments at the same time. " );
 }
 
+if (!argv.minperiods && !argv.minperiodsranked && !argv.minperiodsunranked) {
+    console.log("Warning: No min period number setting detected, your bot is likely to timeout" );
+}
+
+if (!argv.maxperiods && !argv.maxperiodsranked && !argv.maxperiodsunranked) {
+    console.log("Warning: No max period number setting detected, the games are likely to last forever.." );
+}
+
 // console warnings : depreciated features if used
 
 if (argv.botid) {


### PR DESCRIPTION
@roy7 @Dorus 

general look here : https://github.com/wonderingabout/gtp2ogs/tree/hrr-display-rank--fix-rank-calculation

many changes here, most important are :
- now displays rank in reject message in human readable rank (hrr) : for example 5d, 6k, 15k, etc...

- fixed the ranking calculation error : before that fix, a 5.3k is displayed as 5k on OGS, and a 4.8d is displayed as a 5d, while they are respectively 6k and 4d on OGS. Using Math.floor instead of to.Fixed()

- added warning if --maxmaintime is used in combination with --maxmaintimeranked or/and --maxmaintimeunranked

- added clearer reject message instructions if you use fischer time (need to change initial and max time for main time, then need to change increment time for period time. 

**TODO : maybe add a if rule==fischer, display another reject message using increment time**

- other minor changes

all tested to work successfully on beta : 

![missioncomplete2](https://user-images.githubusercontent.com/38690718/52167290-364a1080-2719-11e9-9035-466d915dab20.png)
![missioncomplete](https://user-images.githubusercontent.com/38690718/52167291-36e2a700-2719-11e9-9ea4-db8020efb136.png)
![log22](https://user-images.githubusercontent.com/38690718/52167287-2df1d580-2719-11e9-9e4c-9da630a9d85e.png)
![log11](https://user-images.githubusercontent.com/38690718/52167288-2df1d580-2719-11e9-9366-ced2f10d3a48.png)

@windo 

i saw that you rebased today again, maybe @roy7 wants to merge yours first if its possible
else, sorry again lol :+1: 