### PR TITLE
Rework console warnings + add defaults + no 3 of same family behaviour + minrankranked and co + maxconnectedgames maxconnectedgamesperuser + fix missing exports

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -107,3 +107,21 @@ mean that the gtp2ogs arguments can be abriged like that :
 - `--minperiodtime` -> `--0pt`
 - `--noautohandicap` -> `--nah`
 - `--maxmaintimeranked` -> `--1mtr`
+
+#### H :
+
+For example, if you can either use :
+- `--maxmaintime 600` , the general argument alone**
+- OR, if you want different settings for ranked and unranked games, use for example 
+`--maxmaintimeranked 300 --maxmaintimeunranked 1800` but if you do that then don't use 
+`--minmaintime` !
+  
+in this example, if `--maxmaintimeranked 300 --maxmaintimeunranked 1800` is set, then 
+the general value `--maxmaintime 600` is not taken into account, it will be either 300
+seconds (5 minutes) for ranked games, or 1800 seconds (30 minutes) for unranked games
+
+note that some gtp2ogs arguments come with a default general value : for the same reason, 
+in that case, the default general value will not be taken into account if you set a 
+specific value for ranked and unranked games
+
+

--- a/NOTES.md
+++ b/NOTES.md
@@ -124,4 +124,3 @@ note that some gtp2ogs arguments come with a default general value : for the sam
 in that case, the default general value will not be taken into account if you set a 
 specific value for ranked and unranked games
 
-

--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ Then, the following options are placed in the above ```<gtp2ogsarguments>```
 section. Put a space in between options when there are more than one.  
 Also put a space in between the option and the parameter, for example :
 
-  ```--startupbuffer 2 --boardsize 13,19 --noclock --unrankedonly --maxactivegames 1 --maxmaintime 1200 --ban UserX,playerY ---maxperiodsranked 5```
+  ```--startupbuffer 2 --boardsize 13,19 --noclock --unrankedonly --maxconnectedgamesperuser 1 --maxconnectedgames 10 --maxmaintime 1200 --ban UserX,playerY ---maxperiodsranked 5```
   
 or with ISSA (intuitive semi-syllabic aliases) (see [notes G-](/NOTES.md#g-) for details), 
 the same example becomes :
   
-  ```--sb 2 --bb 13,19 --nc --uo --1ag 1 --1mt 1200 --b UserX,playerY --1pr 5```
+  ```--sb 2 --bb 13,19 --nc --uo --1cgpu 1 --1cg 10 --1mt 1200 --b UserX,playerY --1pr 5```
   
 note : some gtp2ogsarguments have default so they are enabled even if you don't 
 specify them, such as `--komi` which default is automatic even if you dont specify it !
@@ -190,14 +190,14 @@ output to a text file
 
   ```--corrqueue``` or ```--cq``` Process correspondence games one at a time
 
-  ```--maxtotalgames``` or ```--1tg``` Maximum number of total games, maxtotalgames 
-is actually the maximum total number of connected games for your bot (correspondence 
-games are currently included in the connected games count if you use `--persist` ) , 
-which means the maximum number of games your bot can play at the same time (choose 
-a low number to regulate your GPU use) (default 20)
+  ```--maxconnectedgames``` or ```--1cg``` Maximum number of total connected games 
+for all users against your bot (correspondence games are currently included in the 
+connected games count if you use `--persist` ) , which means the maximum number of 
+games your bot can play at the same time (choose a low number to regulate your 
+computer performance and stability) (default 20)
 
-  ```--maxactivegames``` or ```--1ag``` Maximum number of active games per player 
-against this bot (default 3)
+  ```--maxconnectedgamesperuser``` or ```--1cgpu``` Maximum number of connected games 
+per user against this bot (default 3)
 
   ```--startupbuffer``` or ```--sb``` Subtract this many seconds from time available 
 on first move (default 5)

--- a/README.md
+++ b/README.md
@@ -190,20 +190,20 @@ output to a text file
 
   ```--corrqueue``` or ```--cq``` Process correspondence games one at a time
 
-  ```--maxconnectedgames``` or ```--1cg``` Maximum number of total connected games 
-for all users against your bot (correspondence games are currently included in the 
-connected games count if you use `--persist` ) , which means the maximum number of 
-games your bot can play at the same time (choose a low number to regulate your 
-computer performance and stability) (default 20)
+  ```--maxconnectedgames``` or ```--1cg``` Maximum number of connected games 
+for all users against your bot (correspondence games are currently included in 
+the connected games count if you use `--persist` ) , which means the maximum 
+number of games your bot can play at the same time (choose a low number to 
+regulate your computer performance and stability) (default 20)
 
-  ```--maxconnectedgamesperuser``` or ```--1cgpu``` Maximum number of connected games 
-per user against this bot (default 3)
+  ```--maxconnectedgamesperuser``` or ```--1cgpu``` Maximum number of 
+connected games per user against this bot (default 3)
 
-  ```--startupbuffer``` or ```--sb``` Subtract this many seconds from time available 
-on first move (default 5)
+  ```--startupbuffer``` or ```--sb``` Subtract this many seconds from time 
+available on first move (default 5)
 
-  ```--rejectnew``` or ```--r``` Reject all new challenges with the default reject 
-message
+  ```--rejectnew``` or ```--r``` Reject all new challenges with the default 
+reject message
 
   ```--rejectnew --rejectnewmsg "not accepting games because blablablah"``` or 
 ```--r --rm "not accepting games because blablablah"``` if you add the rejectnewmsg 
@@ -268,7 +268,7 @@ for unranked games (rejects time control simple and none)
 unranked games (rejects time control simple and none)
 
   ```--minperiodtime```  or ```--0pt``` Minimum seconds per period (per stone 
-in canadian) (default 5)
+in canadian) (default 10)
 
   ```--maxperiodtime```  or ```--1pt``` Maximum seconds per period (per stone 
 in canadian) (default 120)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,14 @@ the same example becomes :
   
 note : some gtp2ogsarguments have default so they are enabled even if you don't 
 specify them, such as `--komi` which default is automatic even if you dont specify it !
-  
+(default value is overwritten when you set your own value)
+
+note 2 : if an argument has ranked and unranked in the same "family", use:
+- either the general argument alone,
+- OR, if you want to specify different settings for ranked and unranked games, use 
+both the ranked and the unranked argument with wanted values, and then don't use the 
+general argument ! (see [notes H-](/NOTES.md#h-) for details)
+
   below is a list of all possible to use gtp2ogs arguments, use the ones you want only, 
   no need to use them all !
 
@@ -160,7 +167,8 @@ specify them, such as `--komi` which default is automatic even if you dont speci
 
   ```--port``` OGS Port to connect to (default 443)
 
-  ```--timeout``` or ```--t``` Disconnect from a game after this many seconds (if set) (default 0)
+  ```--timeout``` or ```--t``` Disconnect from a game after this many seconds (if set) 
+(default 0)
 
   ```--insecure```  Don't use ssl to connect to the ggs/rest servers
 
@@ -186,15 +194,16 @@ output to a text file
 is actually the maximum total number of connected games for your bot (correspondence 
 games are currently included in the connected games count if you use `--persist` ) , 
 which means the maximum number of games your bot can play at the same time (choose 
-a low number to regulate your GPU use)
+a low number to regulate your GPU use) (default 20)
 
   ```--maxactivegames``` or ```--1ag``` Maximum number of active games per player 
-against this bot
+against this bot (default 3)
 
   ```--startupbuffer``` or ```--sb``` Subtract this many seconds from time available 
 on first move (default 5)
 
-  ```--rejectnew``` or ```--r``` Reject all new challenges with the default reject message
+  ```--rejectnew``` or ```--r``` Reject all new challenges with the default reject 
+message
 
   ```--rejectnew --rejectnewmsg "not accepting games because blablablah"``` or 
 ```--r --rm "not accepting games because blablablah"``` if you add the rejectnewmsg 
@@ -209,8 +218,8 @@ file exists (checked each time, can use for load-balancing)
   ```--boardsize``` or ```--bb``` Possible boardsize values `all` (allows ALL 
 boardsizes, use only if your bot can handle it !), `custom` (allows specified custom 
 boardsize (for example 25x1, 9x9, 17x2 , 15x15, 3x2, etc..), and square board size 
-written in numbers comma separated (for example 9x9, 13x13, 19x19, default is 
-`9,13,19`), see [notes E-](/NOTES.md#e-) for details
+written in numbers comma separated (default is `9,13,19` which is 9x9, 13x13, 19x19), 
+see [notes E-](/NOTES.md#e-) for details
 
   ```--boardsize custom --boardsizewidth 25 --boardsizeheight 1,2,3``` or 
 ```--bb custom --bw 25 --bh 1,2,3``` Allows custom board size (if your bot can 
@@ -223,7 +232,7 @@ in this example 25x1 25x2 25x3 are all allowed boardsizes, see
 When `all` is used alone, all komi values are allowed. When an argument other 
 than `all` is used, only the chosen argument komi values are allowed and all other 
 komi values are rejected see [notes C-](/NOTES.md#c-) and [notes D-](/NOTES.md#d-) 
-for details
+for details (default auto)
 
   ```--ban```  or ```--b``` Comma separated list of user names or IDs 
 (e.g.  UserA,UserB,UserC  do not put spaces in between)
@@ -241,10 +250,10 @@ are banned from playing unranked game
 byoyomi,simple,canadian,absolute,none)
 
   ```--minmaintime```  or ```--0mt``` Minimum seconds of main time (rejects time 
-control simple and none)
+control simple and none) (default 60)
 
   ```--maxmaintime```  or ```--1mt``` Maximum seconds of main time (rejects time 
-control simple and none)
+control simple and none) (default 1800)
 
   ```--minmaintimeranked```  or ```--0mtr``` Minimum seconds of main time for 
 ranked games (rejects time control simple and none)
@@ -259,10 +268,10 @@ for unranked games (rejects time control simple and none)
 unranked games (rejects time control simple and none)
 
   ```--minperiodtime```  or ```--0pt``` Minimum seconds per period (per stone 
-in canadian)
+in canadian) (default 5)
 
   ```--maxperiodtime```  or ```--1pt``` Maximum seconds per period (per stone 
-in canadian)
+in canadian) (default 120)
 
   ```--minperiodtimeranked```  or ```--0ptr``` Minimum seconds per period for 
 ranked games (per stone in canadian)
@@ -276,13 +285,13 @@ unranked games (per stone in canadian)
   ```--maxperiodtimeunranked```  or ```--1ptu``` Maximum seconds per period for 
 unranked games (per stone in canadian)
 
-  ```--minperiods```  or ```--0p``` Minimum number of periods
+  ```--minperiods```  or ```--0p``` Minimum number of periods (default 3)
 
   ```--minperiodsranked```  or ```--0pr``` Minimum number of ranked periods
 
   ```--minperiodsunranked```  or ```--0pu``` Minimum number of unranked periods
 
-  ```--maxperiods```  or ```--1p``` Maximum number of periods
+  ```--maxperiods```  or ```--1p``` Maximum number of periods (default 20)
 
   ```--maxperiodsranked```  or ```--1pr``` Maximum number of ranked periods
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,19 @@ unranked games (per stone in canadian)
 
   ```--minrank```  or ```--0r``` Minimum opponent rank to accept (e.g. 15k)
 
+  ```--minrankranked```  or ```--0rr``` Minimum opponent rank to accept for 
+ranked games (e.g. 15k)
+
+  ```--minrankunranked```  or ```--0ru``` Minimum opponent rank to accept for 
+unranked games (e.g. 15k)
+
   ```--maxrank```  or ```--1r``` Maximum opponent rank to accept (e.g. 1d)
+
+  ```--maxrankranked```  or ```--1rr``` Maximum opponent rank to accept for 
+ranked games (e.g. 1d)
+
+  ```--maxrankunranked```  or ```--1ru``` Maximum opponent rank to accept for 
+unranked games (e.g. 1d)
 
   ```--greeting "Hello, have a nice game"```  or ```--g "Hello, have a nice game"``` 
 Greeting message to appear in chat at first move (ex: "Hello, have a nice game")

--- a/config.js
+++ b/config.js
@@ -66,7 +66,11 @@ exports.updateFromArgv = function() {
         .alias('maxtotalgames', '1tg')
         .alias('maxactivegames', '1ag')
         .alias('minrank', '0r')
+        .alias('minrankranked', '0rr')
+        .alias('minrankunranked', '0ru')
         .alias('maxrank', '1r')
+        .alias('maxrankranked', '1rr')
+        .alias('maxrankunranked', '1ru')
         .alias('minmaintime', '0mt')
         .alias('maxmaintime', '1mt')
         .alias('minmaintimeranked', '0mtr')
@@ -172,7 +176,15 @@ exports.updateFromArgv = function() {
         .describe('maxperiodsunranked', 'Maximum number of unranked periods')
         .describe('minrank', 'Minimum opponent rank to accept (ex: 15k)')
         .string('minrank')
+        .describe('minrankranked', 'Minimum opponent rank to accept for ranked games (ex: 15k)')
+        .string('minrankranked')
+        .describe('minrankunranked', 'Minimum opponent rank to accept for unranked games (ex: 15k)')
+        .string('minrankunranked')
         .describe('maxrank', 'Maximum opponent rank to accept (ex: 1d)')
+        .string('maxrank')
+        .describe('maxrankranked', 'Maximum opponent rank to accept for ranked games (ex: 1d)')
+        .string('maxrankranked')
+        .describe('maxrankunranked', 'Maximum opponent rank to accept for unranked games(ex: 1d)')
         .string('maxrank')
         .describe('greeting', 'Greeting message to appear in chat at first move (ex: "Hello, have a nice game")')
         .string('greeting')
@@ -243,6 +255,14 @@ if (argv.maxperiodtime && (argv.maxperiodtimeranked || argv.maxperiodtimeunranke
 
 if (argv.minperiodtime && (argv.minperiodtimeranked || argv.minperiodtimeunranked)) {
     console.log("Warning: You are using --minperiodtime in combination with --minperiodtimeranked and/or --minperiodtimeunranked.\nUse either --minperiodtime alone, OR --minperiodtimeranked with --minperiodtimeunranked.\nBut don't use the 3 minperiodtime arguments at the same time.");
+}
+
+if (argv.minrank && (argv.minrankranked || argv.minrankunranked)) {
+    console.log("Warning: You are using --minrank in combination with --minrankranked and/or --minrankunranked. \n Use either --minrank alone, OR --minrankranked with --minrankunranked.\nBut don't use the 3 minrank arguments at the same time.");
+}
+
+if (argv.maxrank && (argv.maxrankranked || argv.maxrankunranked)) {
+    console.log("Warning: You are using --maxrank in combination with --maxrankranked and/or --maxrankunranked. \n Use either --maxrank alone, OR --maxrankranked with --maxrankunranked.\nBut don't use the 3 maxrank arguments at the same time.");
 }
 
 if (argv.nopause && (argv.nopauseranked || argv.nopauseunranked)) {
@@ -413,6 +433,50 @@ if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxranke
         }
     }
 
+    if (argv.minrankranked) {
+        let re = /(\d+)([kdp])/;
+        let results = argv.minrank.toLowerCase().match(re);
+
+        if (results) {
+            if (results[2] == "k") {
+                exports.minrankranked = 30 - parseInt(results[1]);
+            } else if (results[2] == "d") {
+                exports.minrankranked = 30 - 1 + parseInt(results[1]);
+            } else if (results[2] == "p") {
+                exports.minrankranked = 36 + parseInt(results[1]);
+                exports.proonly = true;
+            } else {
+                console.error("Invalid minrankranked " + argv.minrankranked);
+                process.exit();
+            }
+        } else {
+            console.error("Could not parse minrankranked " + argv.minrankranked);
+            process.exit();
+        }
+    }
+
+    if (argv.minrankunranked) {
+        let re = /(\d+)([kdp])/;
+        let results = argv.minrankunranked.toLowerCase().match(re);
+
+        if (results) {
+            if (results[2] == "k") {
+                exports.minrankunranked = 30 - parseInt(results[1]);
+            } else if (results[2] == "d") {
+                exports.minrankunranked = 30 - 1 + parseInt(results[1]);
+            } else if (results[2] == "p") {
+                exports.minrankunranked = 36 + parseInt(results[1]);
+                exports.proonly = true;
+            } else {
+                console.error("Invalid minrankunranked " + argv.minrankunranked);
+                process.exit();
+            }
+        } else {
+            console.error("Could not parse minrankunranked " + argv.minrankunranked);
+            process.exit();
+        }
+    }
+
     if (argv.maxrank) {
         let re = /(\d+)([kdp])/;
         let results = argv.maxrank.toLowerCase().match(re);
@@ -430,6 +494,48 @@ if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxranke
             }
         } else {
             console.error("Could not parse maxrank " + argv.maxrank);
+            process.exit();
+        }
+    }
+
+    if (argv.maxrankranked) {
+        let re = /(\d+)([kdp])/;
+        let results = argv.maxrankranked.toLowerCase().match(re);
+
+        if (results) {
+            if (results[2] == "k") {
+                exports.maxrankranked = 30 - parseInt(results[1]);
+            } else if (results[2] == "d") {
+                exports.maxrankranked = 30 - 1 + parseInt(results[1]);
+            } else if (results[2] == "p") {
+                exports.maxrankranked = 36 + parseInt(results[1]);
+            } else {
+                console.error("Invalid maxrankranked " + argv.maxrankranked);
+                process.exit();
+            }
+        } else {
+            console.error("Could not parse maxrankranked " + argv.maxrankranked);
+            process.exit();
+        }
+    }
+
+    if (argv.maxrankunranked) {
+        let re = /(\d+)([kdp])/;
+        let results = argv.maxrankunranked.toLowerCase().match(re);
+
+        if (results) {
+            if (results[2] == "k") {
+                exports.maxrankunranked = 30 - parseInt(results[1]);
+            } else if (results[2] == "d") {
+                exports.maxrankunranked = 30 - 1 + parseInt(results[1]);
+            } else if (results[2] == "p") {
+                exports.maxrankunranked = 36 + parseInt(results[1]);
+            } else {
+                console.error("Invalid maxrankunranked " + argv.maxrankunranked);
+                process.exit();
+            }
+        } else {
+            console.error("Could not parse maxrankunranked " + argv.maxrankunranked);
             process.exit();
         }
     }

--- a/config.js
+++ b/config.js
@@ -114,9 +114,9 @@ exports.updateFromArgv = function() {
         .describe('noclock', 'Do not send any clock/time data to the bot')
         .describe('persist', 'Bot process remains running between moves')
         .describe('corrqueue', 'Process correspondence games one at a time')
-        .describe('maxconnectedgames', 'Maximum number of total games')
+        .describe('maxconnectedgames', 'Maximum number of connected games for all users')
         .default('maxconnectedgames', 20)
-        // maxconnectedgames is actually the maximum total number of connected games for all users 
+        // maxconnectedgames is actually the maximum number of connected games for all users 
         // against your bot, which means the maximum number of games your bot can play at the same time 
         // (choose a low number to regulate your computer performance and stability)
         // (correspondence games are currently included in the total connected games count if you use `--persist` )
@@ -170,7 +170,7 @@ exports.updateFromArgv = function() {
         .describe('minmaintimeunranked', 'Minimum seconds of main time for unranked games (rejects time control simple and none)')
         .describe('maxmaintimeunranked', 'Maximum seconds of main time for unranked games (rejects time control simple and none)')
         .describe('minperiodtime', 'Minimum seconds per period (per stone in canadian)')
-        .default('minperiodtime', 5)
+        .default('minperiodtime', 10)
         .describe('maxperiodtime', 'Maximum seconds per period (per stone in canadian)')
         .default('minperiodtime', 120)
         .describe('minperiodtimeranked', 'Minimum seconds per period for ranked games (per stone in canadian)')

--- a/config.js
+++ b/config.js
@@ -63,8 +63,8 @@ exports.updateFromArgv = function() {
         .alias('boardsizewidth', 'bw')
         .alias('boardsizeheight', 'bh')
         // for below aliases : 0 is min , 1 is max,
-        .alias('maxtotalgames', '1tg')
-        .alias('maxactivegames', '1ag')
+        .alias('maxconnectedgames', '1cg')
+        .alias('maxconnectedgamesperuser', '1cgpu')
         .alias('minrank', '0r')
         .alias('minrankranked', '0rr')
         .alias('minrankunranked', '0ru')
@@ -114,13 +114,14 @@ exports.updateFromArgv = function() {
         .describe('noclock', 'Do not send any clock/time data to the bot')
         .describe('persist', 'Bot process remains running between moves')
         .describe('corrqueue', 'Process correspondence games one at a time')
-        .describe('maxtotalgames', 'Maximum number of total games')
-        .default('maxtotalgames', 20)
-        // maxtotalgames is actually the maximum total number of connected games for your bot 
-        // which means the maximum number of games your bot can play at the same time (choose a low number to regulate your GPU use)
+        .describe('maxconnectedgames', 'Maximum number of total games')
+        .default('maxconnectedgames', 20)
+        // maxconnectedgames is actually the maximum total number of connected games for all users 
+        // against your bot, which means the maximum number of games your bot can play at the same time 
+        // (choose a low number to regulate your computer performance and stability)
         // (correspondence games are currently included in the total connected games count if you use `--persist` )
-        .describe('maxactivegames', 'Maximum number of active games per player against this bot')
-        .default('maxactivegames', 3)
+        .describe('maxconnectedgamesperuser', 'Maximum number of connected games per user against this bot')
+        .default('maxconnectedgamesperuser', 3)
         .describe('startupbuffer', 'Subtract this many seconds from time available on first move')
         .default('startupbuffer', 5)
         .describe('rejectnew', 'Reject all new challenges with the default reject message')
@@ -320,7 +321,15 @@ if (argv.maxunrankedhandicap) {
     console.log("Warning: --minrankedhandicap argument is no longer supported. Use --maxhandicapunranked instead.");
 }
 
-if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxrankedhandicap || argv.minunrankedhandicap || argv.maxunrankedhandicap) {
+if (argv.maxtotalgames) {
+    console.log("Warning: --maxtotalgames argument has been renamed to --maxconnectedgames. Use --maxconnectedgames instead.");
+}
+
+if (argv.maxactivegames) {
+    console.log("Warning: --maxactivegames argument has been renamed to --maxconnectedgamesperuser. Use --maxconnectedgamesperuser instead.");
+}
+
+if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxrankedhandicap || argv.minunrankedhandicap || argv.maxunrankedhandicap || argv.maxtotalgames || argv.maxactivegames) {
     console.log("\n"); /*IF there is a warning, we skip a line to make it more pretty*/
 }
 

--- a/config.js
+++ b/config.js
@@ -407,7 +407,7 @@ if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxranke
 
     if (argv.banunranked) {
         for (let i of argv.banunranked.split(',')) {
-            banned_unranked_users[i] = true;
+            exports.banned_unranked_users[i] = true;
         }
     }
 

--- a/connection.js
+++ b/connection.js
@@ -318,12 +318,41 @@ class Connection {
             return { reject: true, msg: "Minimum rank is " + humanReadableMinRank + ", your rank is too low." };
         }
 
+        if ((user.ranking < config.minrankranked) && notification.ranked) {
+            let humanReadableUserRank = rankToString(user.ranking);
+            let humanReadableMinRank = rankToString(config.minrankranked);
+            conn_log(user.username + " ranking too low: " + humanReadableUserRank + " : min for ranked games is " + humanReadableMinRank);
+            return { reject: true, msg: "Minimum rank for ranked games is " + humanReadableMinRank + ", your rank is too low, try unranked game" };
+        }
+
+        if ((user.ranking < config.minrankunranked) && !notification.ranked) {
+            let humanReadableUserRank = rankToString(user.ranking);
+            let humanReadableMinRank = rankToString(config.minrankunranked);
+            conn_log(user.username + " ranking too low: " + humanReadableUserRank + " : min for ranked games is " + humanReadableMinRank);
+            return { reject: true, msg: "Minimum rank for unranked games is " + humanReadableMinRank + ", your rank is too low" };
+        }
+
         if (user.ranking > config.maxrank) {
             let humanReadableUserRank = rankToString(user.ranking);
             let humanReadableMaxRank = rankToString(config.maxrank);
             conn_log(user.username + " ranking too high: " + humanReadableUserRank + " : max is " + humanReadableMaxRank);
             return { reject: true, msg: "Maximum rank is " + humanReadableMaxRank + ", your rank is too high." };
         }
+
+        if ((user.ranking > config.maxrankranked) && notification.ranked) {
+            let humanReadableUserRank = rankToString(user.ranking);
+            let humanReadableMaxRank = rankToString(config.maxrank);
+            conn_log(user.username + " ranking too high: " + humanReadableUserRank + " : max for ranked games is " + humanReadableMaxRank);
+            return { reject: true, msg: "Maximum rank for ranked games is " + humanReadableMaxRank + ", your rank is too high, try unranked game" };
+        }
+
+        if ((user.ranking > config.maxrankunranked) && !notification.ranked) {
+            let humanReadableUserRank = rankToString(user.ranking);
+            let humanReadableMaxRank = rankToString(config.maxrank);
+            conn_log(user.username + " ranking too high: " + humanReadableUserRank + " : max for unranked games is " + humanReadableMaxRank);
+            return { reject: true, msg: "Maximum rank for unranked games is " + humanReadableMaxRank + ", your rank is too high" };
+        }
+
 
         return { reject: false }; // OK !
 

--- a/connection.js
+++ b/connection.js
@@ -311,7 +311,7 @@ class Connection {
             return { reject: true, msg: "Currently, " + Object.keys(this.connected_games).length + " games are being played by this bot, maximum is " + config.maxtotalgames + " (if you see this message and you dont see any game on the bot profile page, it is because private game(s) are being played) , try again later " };
         }
 
-        if (user.ranking < config.minrank) {
+        if ((user.ranking < config.minrank) && !config.minrankranked && !config.minrankunranked) {
             let humanReadableUserRank = rankToString(user.ranking);
             let humanReadableMinRank = rankToString(config.minrank);
             conn_log(user.username + " ranking too low: " + humanReadableUserRank + " : min is " + humanReadableMinRank);
@@ -332,7 +332,7 @@ class Connection {
             return { reject: true, msg: "Minimum rank for unranked games is " + humanReadableMinRank + ", your rank is too low" };
         }
 
-        if (user.ranking > config.maxrank) {
+        if ((user.ranking > config.maxrank) && !config.maxrankranked && !config.maxrankunranked) {
             let humanReadableUserRank = rankToString(user.ranking);
             let humanReadableMaxRank = rankToString(config.maxrank);
             conn_log(user.username + " ranking too high: " + humanReadableUserRank + " : max is " + humanReadableMaxRank);
@@ -415,7 +415,7 @@ class Connection {
             return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board HEIGHT (" + notification.height + ") is not allowed, please choose one of these allowed CUSTOM board HEIGHT values : " + config.boardsizeheight };
         }
 
-        if (config.noautohandicap && notification.handicap == -1) {
+        if (config.noautohandicap && notification.handicap == -1 && !config.noautohandicapranked && !config.noautohandicapunranked) {
             conn_log("no autohandicap, rejecting challenge") ;
             return { reject: true, msg: "For easier bot management, automatic handicap is disabled on this bot, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones" };
 	}
@@ -430,12 +430,12 @@ class Connection {
             return { reject: true, msg: "For easier bot management, automatic handicap is disabled for unranked games on this bot, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones" };
 	}
 
-        if (notification.handicap < config.minhandicap) {
+        if (notification.handicap < config.minhandicap && !config.minhandicapranked && !config.minhandicapunranked) {
             conn_log("Min handicap is " + config.minhandicap);
             return { reject: true, msg: "Minimum handicap is " + config.minhandicap + " , please increase the number of handicap stones " };
         }
 
-        if (notification.handicap > config.maxhandicap) {
+        if (notification.handicap > config.maxhandicap && !config.maxhandicapranked && !config.maxhandicapunranked) {
             conn_log("Max handicap is " + config.maxhandicap);
             return { reject: true, msg: "Maximum handicap is " + config.maxhandicap + " , please reduce the number of handicap stones " };
         }
@@ -501,7 +501,7 @@ class Connection {
                 universalMaintimeMinimumMaximumSentence = "Minimum ";
                 universalMaintimeIncreaseDecreaseSentence = ", please increase ";
                 let universalMaintimeConnSentence = user.username + " wanted main time below minimum main time ";
-                if (config.minmaintime) {
+                if (config.minmaintime && !config.minmaintimeranked && !config.minmaintimeunranked) {
                     universalMaintimeNumber = config.minmaintime;
                     universalMaintimeToString = timespanToDisplayString(config.minmaintime);
                     universalMaintimeForRankedUnrankedSentence = "is ";
@@ -553,7 +553,7 @@ class Connection {
                 universalMaintimeMinimumMaximumSentence = "Maximum ";
                 universalMaintimeIncreaseDecreaseSentence = ", please reduce ";
                 let universalMaintimeConnSentence = user.username + " wanted main time above maximum main time ";
-                if (config.maxmaintime) {
+                if (config.maxmaintime && !config.maxmaintimeranked && !config.maxmaintimeunranked) {
                     universalMaintimeNumber = config.maxmaintime;
                     universalMaintimeToString = timespanToDisplayString(config.maxmaintime);
                     universalMaintimeForRankedUnrankedSentence = "is ";
@@ -603,7 +603,7 @@ class Connection {
         }
         ////// end of *** UHMAEAT : Universal Highly Modulable And Expandable Argv Tree ***
 
-        if (config.minperiods && (t.periods < config.minperiods)) {
+        if (config.minperiods && (t.periods < config.minperiods) && !config.minperiodsranked && !config.minperiodsunranked) {
             conn_log(user.username + " wanted too few periods: " + t.periods);
             return { reject: true, msg: "Minimum number of periods is " + config.minperiods + " , please increase the number of periods" };
         }
@@ -618,17 +618,17 @@ class Connection {
             return { reject: true, msg: "Minimum number of periods for unranked games is " + config.minperiodsunranked + " , please increase the number of periods" };
         }
 
-        if (t.periods > config.maxperiods) {
+        if (config.maxperiods && (t.periods > config.maxperiods) && !config.maxperiodsranked && !config.maxperiodsunranked) {
             conn_log(user.username + " wanted too many periods: " + t.periods);
             return { reject: true, msg: "Maximum number of periods is " + config.maxperiods + " , please reduce the number of periods" };
         }
 
-        if (t.periods > config.maxperiodsranked && notification.ranked) {
+        if (config.maxperiodsranked && (t.periods > config.maxperiodsranked) && notification.ranked) {
             conn_log(user.username + " wanted too many periods ranked: " + t.periods);
             return { reject: true, msg: "Maximum number of periods for ranked games is " + config.maxperiodsranked + " , please reduce the number of periods" };
         }
 
-        if (t.periods > config.maxperiodsunranked && !notification.ranked) {
+        if (config.maxperiodsunranked && (t.periods > config.maxperiodsunranked) && !notification.ranked) {
             conn_log(user.username + " wanted too many periods unranked: " + t.periods);
             return { reject: true, msg: "Maximum number of periods for unranked games is " + config.maxperiodsunranked + " , please reduce the number of periods" };
         }
@@ -663,7 +663,7 @@ class Connection {
                 universalPeriodtimeMinimumMaximumSentence = "Minimum ";
                 universalPeriodtimeIncreaseDecreaseSentence = ", please increase ";
                 let universalPeriodtimeConnSentence = user.username + " wanted period time below minimum period time ";
-                if (config.minperiodtime) {
+                if (config.minperiodtime && !config.minperiodtimeranked && !config.minperiodtimeunranked) {
                     universalPeriodtimeNumber = config.minperiodtime;
                     universalPeriodtimeToString = timespanToDisplayString(config.minperiodtime);
                     universalPeriodtimeForRankedUnrankedSentence = "is ";
@@ -710,7 +710,7 @@ class Connection {
                         // canadian period time is already for n number of stones, dont divide by stone
                         // e.g. 300 seconds divided by 25 stones = 12 seconds / stone
                         // first we reconvert displayedTimeToString
-                        if (config.minperiodtime) {
+                        if (config.minperiodtime && !config.minperiodtimeranked && !config.minperiodtimeunranked) {
                             universalPeriodtimeNumber = (config.minperiodtime * t.stones_per_period);
                             universalPeriodtimeToString = timespanToDisplayString(universalPeriodtimeNumber);
                         }
@@ -736,7 +736,7 @@ class Connection {
                 universalPeriodtimeMinimumMaximumSentence = "Maximum ";
                 universalPeriodtimeIncreaseDecreaseSentence = ", please reduce ";
                 let universalPeriodtimeConnSentence = user.username + " wanted period time above maximum period time ";
-                if (config.maxperiodtime) {
+                if (config.maxperiodtime && !config.maxperiodtimeranked && !config.maxperiodtimeunranked) {
                     universalPeriodtimeNumber = config.maxperiodtime;
                     universalPeriodtimeToString = timespanToDisplayString(config.maxperiodtime);
                     universalPeriodtimeForRankedUnrankedSentence = "is ";
@@ -782,7 +782,7 @@ class Connection {
                         // canadian period time is already for n number of stones, dont divide by stone
                         // e.g. 300 seconds divided by 25 stones = 12 seconds / stone
                         // first we reconvert displayedTimeToString
-                        if (config.maxperiodtime) {
+                        if (config.maxperiodtime && !config.maxperiodtimeranked && !config.maxperiodtimeunranked) {
                             universalPeriodtimeNumber = (config.maxperiodtime * t.stones_per_period);
                             universalPeriodtimeToString = timespanToDisplayString(universalPeriodtimeNumber);
                         }

--- a/connection.js
+++ b/connection.js
@@ -138,8 +138,8 @@ class Connection {
             }
         });
 
-        socket.on('connected_game', (gamedata) => {
-            if (config.DEBUG) conn_log("connected_game:", JSON.stringify(gamedata));
+        socket.on('active_game', (gamedata) => {
+            if (config.DEBUG) conn_log("active_game:", JSON.stringify(gamedata));
 
             // OGS auto scores bot games now, no removal processing is needed by the bot.
             //
@@ -162,7 +162,7 @@ class Connection {
             let game = this.connectToGame(gamedata.id);
 
             if (gamedata.phase == "play" && gamedata.player_to_move == this.bot_id) {
-                // Going to make moves based on gamedata or moves coming in for now on, instead of connected_game updates
+                // Going to make moves based on gamedata or moves coming in for now on, instead of active_game updates
                 // game.makeMove(gamedata.move_number);
 
                 if (config.timeout)
@@ -178,15 +178,15 @@ class Connection {
                 }
             }
 
-            // When a game ends, we don't get a "finished" connected_game.phase. Probably since the game is no
-            // longer connected.(Update: We do get finished connected_game events? Unclear why I added prior note.)
+            // When a game ends, we don't get a "finished" active_game.phase. Probably since the game is no
+            // longer active.(Update: We do get finished active_game events? Unclear why I added prior note.)
             //
             if (gamedata.phase == "finished") {
                 if (config.DEBUG) conn_log(gamedata.id, "gamedata.phase == finished");
 
                 // XXX We want to disconnect right away here, but there's a game over race condition
                 //     on server side: sometimes /gamedata event with game outcome is sent after
-                //     connected_game, so it's lost since there's no game to handle it anymore...
+                //     active_game, so it's lost since there's no game to handle it anymore...
                 //     Work around it with a timeout for now.
                 setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
             } else {

--- a/game.js
+++ b/game.js
@@ -90,7 +90,7 @@ class Game {
                 }
             }
 
-            // active_game isn't handling this for us any more. If it is our move, call makeMove.
+            // connected_game isn't handling this for us any more. If it is our move, call makeMove.
             //
             if (this.state.phase == "play" && this.state.clock.current_player == this.conn.bot_id) {
                 if (config.corrqueue && this.state.time_control.speed == "correspondence" && Game.corr_moves_processing > 0) {

--- a/game.js
+++ b/game.js
@@ -105,10 +105,20 @@ class Game {
             if (!this.connected) return;
             if (config.DEBUG) this.log("clock:", JSON.stringify(clock));
 
-            if ((config.nopause || (config.nopauseranked && this.state.ranked) || (config.nopauseunranked && this.state.ranked == false))
+            if (config.nopause && !config.nopauseranked && !config.nopauseunranked 
                 && clock.pause && clock.pause.paused && clock.pause.pause_control
                 && !clock.pause.pause_control["stone-removal"] && !clock.pause.pause_control.system && !clock.pause.pause_control.weekend
                 && !clock.pause.pause_control["vacation-" + clock.black_player_id] && !clock.pause.pause_control["vacation-" + clock.white_player_id]) {
+                if (config.DEBUG) this.log("Pausing not allowed. Resuming game.");
+                this.resumeGame();
+            }
+
+            if (config.nopauseranked && this.state.ranked) {
+                if (config.DEBUG) this.log("Pausing not allowed. Resuming game.");
+                this.resumeGame();
+            }
+
+            if (config.nopauseunranked && (this.state.ranked == false)) {
                 if (config.DEBUG) this.log("Pausing not allowed. Resuming game.");
                 this.resumeGame();
             }

--- a/game.js
+++ b/game.js
@@ -90,7 +90,7 @@ class Game {
                 }
             }
 
-            // connected_game isn't handling this for us any more. If it is our move, call makeMove.
+            // active_game isn't handling this for us any more. If it is our move, call makeMove.
             //
             if (this.state.phase == "play" && this.state.clock.current_player == this.conn.bot_id) {
                 if (config.corrqueue && this.state.time_control.speed == "correspondence" && Game.corr_moves_processing > 0) {
@@ -114,12 +114,12 @@ class Game {
             }
 
             if (config.nopauseranked && this.state.ranked) {
-                if (config.DEBUG) this.log("Pausing not allowed. Resuming game.");
+                if (config.DEBUG) this.log("Pausing for ranked games not allowed. Resuming game.");
                 this.resumeGame();
             }
 
             if (config.nopauseunranked && (this.state.ranked == false)) {
-                if (config.DEBUG) this.log("Pausing not allowed. Resuming game.");
+                if (config.DEBUG) this.log("Pausing for unranked games not allowed. Resuming game.");
                 this.resumeGame();
             }
 


### PR DESCRIPTION
Many new changes in this PR, some are important :

general look here : https://github.com/wonderingabout/gtp2ogs/tree/rework-console-minrankranked-and-co 

- removed console warnings for maxmaintime and co "setting not detected"
- instead, using default values hassle-free, large and friendly for rescue value purposes
- change behaviour if 3 arguments of same family are used : for arguments that have a general+ranked+unranked possible values, new behaviour is now, for example for `--maxmaintime` :  general value (default or manually inputted by bot admin) will be taken into account only if no specific value is used (ranked and/or unranked); else bot admin will have to set up both ranked and unranked values desired and general value will not be taken into account (added notes about that on readme)
- added `--minrankranked` and co : if bot admin wants to specify different minrank and maxrank for ranked and unranked games
- renamed `--maxactivegames` and `--maxtotalgames` to the clearer and more powerful `--maxconnectedgames` and `--maxconnectedgamesperuser` : these names are clearer but also more powerful : in the future, someone may want to add a maxtotalgames per bot and/or per user which is something different (max number of total games in the list on ogs profile, see gnugo page for example : it has a lot of games in the list but gnugo is not connected to almost any of them, bot admins may want to have the option to regulate that in the future) @lemonsqueeze 
- updated readme and ISSA to take all that into account

@roy7 @Dorus @windo @lemonsqueeze 