### PR TITLE
enhance display for komi and boardsize in human readable, add --boardsizeranked, --komiranked, --speedranked, --timecontrolranked and their unranked equivalent, + various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ shown in
 [Most common usage earlier](#4-most-common-usage--start-gtp2ogsjs-using-nodejs)
 
 note : some gtp2ogsarguments have default so they are enabled even if you don't 
-specify them, such as `--komi` which default is "Automatic" even if you dont specify 
+specify them, such as `--komi` which default is "automatic" even if you dont specify 
 it ! (default value is overwritten when you set your own value)
 
 note 2 : if an argument has ranked and unranked in the same "family", use:

--- a/config.js
+++ b/config.js
@@ -38,8 +38,10 @@ exports.allow_all_komi_ranked = false;
 exports.allowed_komi_ranked = [];
 exports.allow_all_komi_unranked = false;
 exports.allowed_komi_unranked = [];
-exports.allowed_timecontrols = {};
 exports.allowed_speeds = {};
+exports.allowed_speeds_ranked = {};
+exports.allowed_speeds_unranked = {};
+exports.allowed_timecontrols = {};
 
 exports.updateFromArgv = function() {
     let optimist = require("optimist")
@@ -125,6 +127,8 @@ exports.updateFromArgv = function() {
         .string('banunranked')
         .describe('speed', 'Game speed(s) to accept')
         .default('speed', 'blitz,live,correspondence')
+        .describe('speedranked', 'Game speed(s) to accept for ranked games')
+        .describe('speedunranked', 'Game speed(s) to accept for unranked games')
         .describe('timecontrol', 'Time control(s) to accept')
         .default('timecontrol', 'fischer,byoyomi,simple,canadian,absolute,none')
         // 1- for "absolute", bot admin can allow absolute if want, but then 
@@ -619,6 +623,18 @@ exports.updateFromArgv = function() {
     if (argv.speed) {
         for (let i of argv.speed.split(',')) {
             exports.allowed_speeds[i] = true;
+        }
+    }
+
+    if (argv.speedranked) {
+        for (let i of argv.speedranked.split(',')) {
+            exports.allowed_speeds_ranked[i] = true;
+        }
+    }
+
+    if (argv.speedunranked) {
+        for (let i of argv.speedunranked.split(',')) {
+            exports.allowed_speeds_unranked[i] = true;
         }
     }
 

--- a/config.js
+++ b/config.js
@@ -80,12 +80,12 @@ exports.updateFromArgv = function() {
         // The default is "9,13,19" (square board sizes only), see README for details
         .describe('komi', 'Allowed komi values')
         .string('komi')
-        .default('komi', 'auto')
+        .default('komi', 'Automatic')
         // behaviour: --komi may be specified as 
-        // "auto" (Automatic), 
+        // "Automatic" (accept Automatic komi)
         // "all" (accept all komi values), 
         // or comma separated list of explicit values.
-        // The default is "auto", see README for details
+        // The default is "Automatic", see README and OPTIONS-LIST for details
         .describe('ban', 'Comma separated list of user names or IDs')
         .string('ban')
         .describe('banranked', 'Comma separated list of user names or IDs')
@@ -243,6 +243,13 @@ exports.updateFromArgv = function() {
 
     if (argv.nopause && (argv.nopauseranked || argv.nopauseunranked)) {
         console.log("Warning: You are using --nopause in combination with --nopauseranked and/or --nopauseunranked. \n Use either --nopause alone, OR --nopauseranked with --nopauseunranked.\nBut don't use the 3 nopause arguments at the same time.");
+    }
+
+    if (argv.komi) {
+        if (argv.komi.includes(`auto`)) {
+            console.log("Warning: /--komi auto/ has been renamed to /--komi Automatic/\n");
+            // we skip a line here, not below, because this argv may be undefined if not used by bot admin
+        }
     }
 
     console.log("\n"); /*after final warning, we skip a line to make it more pretty*/
@@ -478,7 +485,7 @@ exports.updateFromArgv = function() {
         for (let komi of argv.komi.split(',')) {
             if (komi == "all") {
                 exports.allow_all_komi = true;
-            } else if (komi == "auto") {
+            } else if (komi == "Automatic") {
                 exports.allowed_komi[null] = true;
             } else {
                 exports.allowed_komi[komi] = true;

--- a/config.js
+++ b/config.js
@@ -40,8 +40,6 @@ exports.allow_all_komi_unranked = false;
 exports.allowed_komi_unranked = [];
 exports.allowed_timecontrols = {};
 exports.allowed_speeds = {};
-exports.allowed_custom_boardsizewidth = [];
-exports.allowed_custom_boardsizeheight = [];
 
 exports.updateFromArgv = function() {
     let optimist = require("optimist")

--- a/config.js
+++ b/config.js
@@ -110,16 +110,16 @@ exports.updateFromArgv = function() {
         // The default is "9,13,19" (square board sizes only), see README for details
         .describe('komi', 'Allowed komi values')
         .string('komi')
-        .default('komi', 'Automatic')
+        .default('komi', 'automatic')
         .describe('komiranked', 'Allowed komi values for ranked games')
         .string('komiranked')
         .describe('komiunranked', 'Allowed komi values for unranked games')
         .string('komiunranked')
         // behaviour: --komi may be specified as 
-        // "Automatic" (accept Automatic komi)
+        // "automatic" (accept automatic komi)
         // "all" (accept all komi values), 
         // or comma separated list of explicit values.
-        // The default is "Automatic", see README and OPTIONS-LIST for details
+        // The default is "automatic", see README and OPTIONS-LIST for details
         .describe('ban', 'Comma separated list of user names or IDs')
         .string('ban')
         .describe('banranked', 'Comma separated list of user names or IDs')
@@ -285,21 +285,21 @@ exports.updateFromArgv = function() {
 
     if (argv.komi) {
         if (argv.komi.includes(`auto`)) {
-            console.log("Warning: /--komi auto/ has been renamed to /--komi Automatic/\n");
+            console.log("Warning: /--komi auto/ has been renamed to /--komi automatic/\n");
             // we skip a line here, not below, because this argv may be undefined if not used by bot admin
         }
     }
 
     if (argv.komiranked) {
         if (argv.komiranked.includes(`auto`)) {
-            console.log("Warning: /--komiranked auto/ has been renamed to /--komiranked Automatic/\n");
+            console.log("Warning: /--komiranked auto/ has been renamed to /--komiranked automatic/\n");
             // we skip a line here, not below, because this argv may be undefined if not used by bot admin
         }
     }
 
     if (argv.komiunranked) {
         if (argv.komiunranked.includes(`auto`)) {
-            console.log("Warning: /--komiunranked auto/ has been renamed to /--komiunranked Automatic/\n");
+            console.log("Warning: /--komiunranked auto/ has been renamed to /--komiunranked automatic/\n");
             // we skip a line here, not below, because this argv may be undefined if not used by bot admin
         }
     }
@@ -591,7 +591,7 @@ if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxranke
         for (let komi of argv.komi.split(',')) {
             if (komi == "all") {
                 exports.allow_all_komi = true;
-            } else if (komi == "Automatic") {
+            } else if (komi == "automatic") {
                 exports.allowed_komi[null] = true;
             } else {
                 exports.allowed_komi[komi] = true;
@@ -603,7 +603,7 @@ if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxranke
         for (let komiranked of argv.komiranked.split(',')) {
             if (komiranked == "all") {
                 exports.allow_all_komi_ranked = true;
-            } else if (komiranked == "Automatic") {
+            } else if (komiranked == "automatic") {
                 exports.allowed_komi_ranked[null] = true;
             } else {
                 exports.allowed_komi_ranked[komiranked] = true;
@@ -615,7 +615,7 @@ if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxranke
         for (let komiunranked of argv.komiunranked.split(',')) {
             if (komiunranked == "all") {
                 exports.allow_all_komi_unranked = true;
-            } else if (komiunranked == "Automatic") {
+            } else if (komiunranked == "automatic") {
                 exports.allowed_komi_unranked[null] = true;
             } else {
                 exports.allowed_komi_unranked[komiunranked] = true;

--- a/config.js
+++ b/config.js
@@ -339,9 +339,9 @@ exports.updateFromArgv = function() {
         console.log("Warning: --maxactivegames argument has been renamed to --maxconnectedgamesperuser. Use --maxconnectedgamesperuser instead.");
     }
 
-if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxrankedhandicap || argv.minunrankedhandicap || argv.maxunrankedhandicap || argv.maxtotalgames || argv.maxactivegames || argv.maxmaintime || argv.maxmaintimeranked || argv.maxmaintimeunranked || argv.minmaintime || argv.minmaintimeranked || argv.minmaintimeunranked || argv.maxperiodtime || argv.maxperiodtimeranked || argv.maxperiodtimeunranked || argv.minperiodtime || argv.minperiodtimeranked || argv.minperiodtimeunranked) {
-    console.log("\n"); /*IF there is a warning, we skip a line to make it more pretty*/
-}
+    if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxrankedhandicap || argv.minunrankedhandicap || argv.maxunrankedhandicap || argv.maxtotalgames || argv.maxactivegames || argv.maxmaintime || argv.maxmaintimeranked || argv.maxmaintimeunranked || argv.minmaintime || argv.minmaintimeranked || argv.minmaintimeunranked || argv.maxperiodtime || argv.maxperiodtimeranked || argv.maxperiodtimeunranked || argv.minperiodtime || argv.minperiodtimeranked || argv.minperiodtimeunranked) {
+        console.log("\n"); /*IF there is a warning, we skip a line to make it more pretty*/
+    }
 
     // end of console messages
 

--- a/config.js
+++ b/config.js
@@ -17,7 +17,6 @@ exports.check_rejectnew = function() {};
 exports.banned_users = {};
 exports.banned_ranked_users = {};
 exports.banned_unranked_users = {};
-exports.allow_all_komi = false;
 exports.allowed_sizes = [];
 exports.allow_all_sizes = false;
 exports.allow_custom_sizes = false;
@@ -33,7 +32,12 @@ exports.allow_all_sizes_unranked = false;
 exports.allow_custom_sizes_unranked = false;
 exports.allowed_custom_boardsizewidth_unranked = [];
 exports.allowed_custom_boardsizeheight_unranked = [];
+exports.allow_all_komi = false;
 exports.allowed_komi = [];
+exports.allow_all_komi_ranked = false;
+exports.allowed_komi_ranked = [];
+exports.allow_all_komi_unranked = false;
+exports.allowed_komi_unranked = [];
 exports.allowed_timecontrols = {};
 exports.allowed_speeds = {};
 exports.allowed_custom_boardsizewidth = [];
@@ -106,6 +110,10 @@ exports.updateFromArgv = function() {
         .describe('komi', 'Allowed komi values')
         .string('komi')
         .default('komi', 'Automatic')
+        .describe('komiranked', 'Allowed komi values for ranked games')
+        .string('komiranked')
+        .describe('komiunranked', 'Allowed komi values for unranked games')
+        .string('komiunranked')
         // behaviour: --komi may be specified as 
         // "Automatic" (accept Automatic komi)
         // "all" (accept all komi values), 
@@ -273,6 +281,20 @@ exports.updateFromArgv = function() {
     if (argv.komi) {
         if (argv.komi.includes(`auto`)) {
             console.log("Warning: /--komi auto/ has been renamed to /--komi Automatic/\n");
+            // we skip a line here, not below, because this argv may be undefined if not used by bot admin
+        }
+    }
+
+    if (argv.komiranked) {
+        if (argv.komiranked.includes(`auto`)) {
+            console.log("Warning: /--komiranked auto/ has been renamed to /--komiranked Automatic/\n");
+            // we skip a line here, not below, because this argv may be undefined if not used by bot admin
+        }
+    }
+
+    if (argv.komiunranked) {
+        if (argv.komiunranked.includes(`auto`)) {
+            console.log("Warning: /--komiunranked auto/ has been renamed to /--komiunranked Automatic/\n");
             // we skip a line here, not below, because this argv may be undefined if not used by bot admin
         }
     }
@@ -506,18 +528,6 @@ exports.updateFromArgv = function() {
         }
     }
 
-    if (argv.komi) {
-        for (let komi of argv.komi.split(',')) {
-            if (komi == "all") {
-                exports.allow_all_komi = true;
-            } else if (komi == "Automatic") {
-                exports.allowed_komi[null] = true;
-            } else {
-                exports.allowed_komi[komi] = true;
-            }
-        }
-    }
-
     if (argv.boardsize) {
         for (let boardsize of argv.boardsize.split(',')) {
             if (boardsize == "all") {
@@ -568,6 +578,42 @@ exports.updateFromArgv = function() {
                 }
             } else {
                 exports.allowed_sizes_unranked[boardsizeunranked] = true;
+            }
+        }
+    }
+
+    if (argv.komi) {
+        for (let komi of argv.komi.split(',')) {
+            if (komi == "all") {
+                exports.allow_all_komi = true;
+            } else if (komi == "Automatic") {
+                exports.allowed_komi[null] = true;
+            } else {
+                exports.allowed_komi[komi] = true;
+            }
+        }
+    }
+
+    if (argv.komiranked) {
+        for (let komiranked of argv.komiranked.split(',')) {
+            if (komiranked == "all") {
+                exports.allow_all_komi_ranked = true;
+            } else if (komiranked == "Automatic") {
+                exports.allowed_komi_ranked[null] = true;
+            } else {
+                exports.allowed_komi_ranked[komiranked] = true;
+            }
+        }
+    }
+
+    if (argv.komiunranked) {
+        for (let komiunranked of argv.komiunranked.split(',')) {
+            if (komiunranked == "all") {
+                exports.allow_all_komi_unranked = true;
+            } else if (komiunranked == "Automatic") {
+                exports.allowed_komi_unranked[null] = true;
+            } else {
+                exports.allowed_komi_unranked[komiunranked] = true;
             }
         }
     }

--- a/config.js
+++ b/config.js
@@ -85,7 +85,6 @@ exports.updateFromArgv = function() {
         // --rejectnew --rejectnewmsg "this bot is not playing today because blablablah, try again at x time, sorry"
         .describe('rejectnewfile', 'Reject new challenges if file exists (checked each time, can use for load-balancing)')
         .describe('boardsize', 'Board size(s) to accept')
-        .describe('boardsize', 'Board size(s) to accept')
         .string('boardsize')
         .default('boardsize', '9,13,19')
         .describe('boardsizeranked', 'Board size(s) to accept for ranked games')

--- a/config.js
+++ b/config.js
@@ -18,12 +18,24 @@ exports.banned_users = {};
 exports.banned_ranked_users = {};
 exports.banned_unranked_users = {};
 exports.allow_all_komi = false;
-exports.allowed_komi = [];
 exports.allowed_sizes = [];
-exports.allowed_timecontrols = {};
-exports.allowed_speeds = {};
 exports.allow_all_sizes = false;
 exports.allow_custom_sizes = false;
+exports.allowed_custom_boardsizewidth = [];
+exports.allowed_custom_boardsizeheight = [];
+exports.allowed_sizes_ranked = [];
+exports.allow_all_sizes_ranked = false;
+exports.allow_custom_sizes_ranked = false;
+exports.allowed_custom_boardsizewidth_ranked = [];
+exports.allowed_custom_boardsizeheight_ranked = [];
+exports.allowed_sizes_unranked = [];
+exports.allow_all_sizes_unranked = false;
+exports.allow_custom_sizes_unranked = false;
+exports.allowed_custom_boardsizewidth_unranked = [];
+exports.allowed_custom_boardsizeheight_unranked = [];
+exports.allowed_komi = [];
+exports.allowed_timecontrols = {};
+exports.allowed_speeds = {};
 exports.allowed_custom_boardsizewidth = [];
 exports.allowed_custom_boardsizeheight = [];
 
@@ -67,12 +79,25 @@ exports.updateFromArgv = function() {
         // --rejectnew --rejectnewmsg "this bot is not playing today because blablablah, try again at x time, sorry"
         .describe('rejectnewfile', 'Reject new challenges if file exists (checked each time, can use for load-balancing)')
         .describe('boardsize', 'Board size(s) to accept')
+        .describe('boardsize', 'Board size(s) to accept')
         .string('boardsize')
         .default('boardsize', '9,13,19')
+        .describe('boardsizeranked', 'Board size(s) to accept for ranked games')
+        .string('boardsizeranked')
+        .describe('boardsizeunranked', 'Board size(s) to accept for unranked games')
+        .string('boardsizeunranked')
+        .describe('boardsizewidth', 'For custom board size(s), specify boardsize width to accept, for example 25')
         .string('boardsizewidth')
-        .describe('boardsizewidth', 'For custom board size(s) to accept, specify boardsize width, for example 25')
+        .describe('boardsizeheight', 'For custom board size(s), specify boardsize height to accept, for example 1')
         .string('boardsizeheight')
-        .describe('boardsizeheight', 'For custom board size(s) to accept, specify boardsize height, for example 1')
+        .describe('boardsizewidthranked', 'For custom board size(s), specify boardsize width to accept for ranked games, for example 25')
+        .string('boardsizewidthranked')
+        .describe('boardsizeheightranked', 'For custom board size(s), specify boardsize height to accept for ranked games, for example 1')
+        .string('boardsizeheightranked')
+        .describe('boardsizewidthunranked', 'For custom board size(s), specify boardsize width to accept for unranked games, for example 25')
+        .string('boardsizewidthunranked')
+        .describe('boardsizeheightunranked', 'For custom board size(s), specify boardsize height to accept for unranked games, for example 1')
+        .string('boardsizeheightunranked')
         // behaviour : --boardsize can be specified as 
         // "custom" (allows board with custom size width x height),
         // "all" (allows ALL boardsizes), 
@@ -511,12 +536,41 @@ exports.updateFromArgv = function() {
         }
     }
 
-    if (argv.timecontrol) {
-        for (let i of argv.timecontrol.split(',')) {
-            exports.allowed_timecontrols[i] = true;
+    if (argv.boardsizeranked) {
+        for (let boardsizeranked of argv.boardsizeranked.split(',')) {
+            if (boardsizeranked == "all") {
+                exports.allow_all_sizes_ranked = true;
+            } else if (boardsizeranked == "custom") {
+                exports.allow_custom_sizes_ranked = true;
+                for (let boardsizewidthranked of argv.boardsizewidthranked.split(',')) {
+                    exports.allowed_custom_boardsizewidth_ranked[boardsizewidthranked] = true;
+                }
+                for (let boardsizeheightranked of argv.boardsizeheightranked.split(',')) {
+                    exports.allowed_custom_boardsizeheight_ranked[boardsizeheightranked] = true;
+                }
+            } else {
+                exports.allowed_sizes_ranked[boardsizeranked] = true;
+            }
         }
     }
 
+    if (argv.boardsizeunranked) {
+        for (let boardsizeunranked of argv.boardsizeunranked.split(',')) {
+            if (boardsizeunranked == "all") {
+                exports.allow_all_sizes_unranked = true;
+            } else if (boardsizeunranked == "custom") {
+                exports.allow_custom_sizes_unranked = true;
+                for (let boardsizewidthunranked of argv.boardsizewidthunranked.split(',')) {
+                    exports.allowed_custom_boardsizewidth_unranked[boardsizewidthunranked] = true;
+                }
+                for (let boardsizeheightunranked of argv.boardsizeheightunranked.split(',')) {
+                    exports.allowed_custom_boardsizeheight_unranked[boardsizeheightunranked] = true;
+                }
+            } else {
+                exports.allowed_sizes_unranked[boardsizeunranked] = true;
+            }
+        }
+    }
 
     if (argv.speed) {
         for (let i of argv.speed.split(',')) {

--- a/config.js
+++ b/config.js
@@ -42,6 +42,8 @@ exports.allowed_speeds = {};
 exports.allowed_speeds_ranked = {};
 exports.allowed_speeds_unranked = {};
 exports.allowed_timecontrols = {};
+exports.allowed_timecontrols_ranked = {};
+exports.allowed_timecontrols_unranked = {};
 
 exports.updateFromArgv = function() {
     let optimist = require("optimist")
@@ -130,7 +132,9 @@ exports.updateFromArgv = function() {
         .describe('speedranked', 'Game speed(s) to accept for ranked games')
         .describe('speedunranked', 'Game speed(s) to accept for unranked games')
         .describe('timecontrol', 'Time control(s) to accept')
-        .default('timecontrol', 'fischer,byoyomi,simple,canadian,absolute,none')
+        .default('timecontrol', 'fischer,byoyomi,simple,canadian')
+        .describe('timecontrolranked', 'Time control(s) to accept for ranked games')
+        .describe('timecontrolunranked', 'Time control(s) to accept for unranked games')
         // 1- for "absolute", bot admin can allow absolute if want, but then 
         // make sure to increase minmaintimeblitz and minmaintimelive to high values
         // 2 - "none" is not default, can be manually allowed in timecontrol argument
@@ -336,9 +340,9 @@ exports.updateFromArgv = function() {
         console.log("Warning: --maxactivegames argument has been renamed to --maxconnectedgamesperuser. Use --maxconnectedgamesperuser instead.");
     }
 
-    if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxrankedhandicap || argv.minunrankedhandicap || argv.maxunrankedhandicap || argv.maxtotalgames || argv.maxactivegames) {
-        console.log("\n"); /*IF there is a warning, we skip a line to make it more pretty*/
-    }
+if (argv.botid || argv.bot || argv.id || argv.minrankedhandicap || argv.maxrankedhandicap || argv.minunrankedhandicap || argv.maxunrankedhandicap || argv.maxtotalgames || argv.maxactivegames || argv.maxmaintime || argv.maxmaintimeranked || argv.maxmaintimeunranked || argv.minmaintime || argv.minmaintimeranked || argv.minmaintimeunranked || argv.maxperiodtime || argv.maxperiodtimeranked || argv.maxperiodtimeunranked || argv.minperiodtime || argv.minperiodtimeranked || argv.minperiodtimeunranked) {
+    console.log("\n"); /*IF there is a warning, we skip a line to make it more pretty*/
+}
 
     // end of console messages
 
@@ -635,6 +639,24 @@ exports.updateFromArgv = function() {
     if (argv.speedunranked) {
         for (let i of argv.speedunranked.split(',')) {
             exports.allowed_speeds_unranked[i] = true;
+        }
+    }
+
+    if (argv.timecontrol) {
+        for (let i of argv.timecontrol.split(',')) {
+            exports.allowed_timecontrols[i] = true;
+        }
+    }
+
+    if (argv.timecontrolranked) {
+        for (let i of argv.timecontrolranked.split(',')) {
+            exports.allowed_timecontrols_ranked[i] = true;
+        }
+    }
+
+    if (argv.timecontrolunranked) {
+        for (let i of argv.timecontrolunranked.split(',')) {
+            exports.allowed_timecontrols_unranked[i] = true;
         }
     }
 

--- a/connection.js
+++ b/connection.js
@@ -352,27 +352,34 @@ class Connection {
             return { reject: true, msg: "This bot accepts Unranked games only. " };
         }
 
-        // for square board sizes only
+        /******** begining of BOARDSIZES *********/
+        // for square board sizes only //
+        /* if not square*/
         if (notification.width != notification.height && !config.allow_all_sizes && !config.allow_custom_sizes) {
             conn_log("board was not square, rejecting challenge");
             return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), Board was not square, please choose a square board size (same width and height, for example 9x9 or 19x19). " };
         }
 
+        /* if square, check if square board size is allowed*/
         if (!config.allowed_sizes[notification.width] && !config.allow_all_sizes && !config.allow_custom_sizes) {
-            conn_log("square board size " + notification.width + "x" + notification.height + " is not an allowed size, rejecting challenge");
-            return { reject: true, msg: "Board size " + notification.width + "x" + notification.height + " is not allowed, please choose one of the allowed square board sizes (same width and height, for example if allowed boardsizes are 9,13,19, it means you can play only 9x9 , 13x13, and 19x19), these are the allowed square board sizes : " + config.boardsize };
+            let boardsizeSquareString = String(config.boardsize); // we convert the value to a string to avoid undefined error later
+            conn_log("square board size " + notification.width + "x" + notification.height + " is not an allowed size");
+            return { reject: true, msg: "Board size " + notification.width + "x" + notification.height + " is not allowed, please choose one of these allowed board sizes " + boardsizeSquareToDisplayString(boardsizeSquareString)};
         }
 
-        // for custom board sizes, including square board sizes if width == height as well
+        // for custom board sizes, including square board sizes if width == height as well //
+        /* if custom, check width */
         if (!config.allow_all_sizes && config.allow_custom_sizes && !config.allowed_custom_boardsizewidth[notification.width]) {
             conn_log("custom board width " + notification.width + " is not an allowed custom board width, rejecting challenge");
             return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board WIDTH (" + notification.width + ") is not allowed, please choose one of these allowed CUSTOM board WIDTH values : " + config.boardsizewidth };
         }
 
+        /* if custom, check height */
         if (!config.allow_all_sizes && config.allow_custom_sizes && !config.allowed_custom_boardsizeheight[notification.height]) {
             conn_log("custom board height " + notification.height + " is not an allowed custom board height, rejecting challenge");
             return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board HEIGHT (" + notification.height + ") is not allowed, please choose one of these allowed CUSTOM board HEIGHT values : " + config.boardsizeheight };
         }
+        /******** end of BOARDSIZES *********/
 
         if (config.noautohandicap && notification.handicap == -1 && !config.noautohandicapranked && !config.noautohandicapunranked) {
             conn_log("no autohandicap, rejecting challenge") ;
@@ -1526,7 +1533,7 @@ function rankToString(r) { /* {{{ */
     else          return (30-r) + 'k'; // r<30 : 1 kyu or weaker
 } /* }}} */
 
-function timespanToDisplayString(timespan) {
+function timespanToDisplayString(timespan) { /* {{{ */
     let ss = timespan % 60;
     let mm = Math.floor(timespan / 60 % 60);
     let hh = Math.floor(timespan / (60*60) % 24);
@@ -1536,6 +1543,14 @@ function timespanToDisplayString(timespan) {
     .map((e, i) => e === 0 ? "" : `${e} ${text[i]}`)
     .filter(e => e !== "")
     .join(" ");
+} /* }}} */
+
+function boardsizeSquareToDisplayString(boardsizeSquare) { /* {{{ */
+    return boardsizeSquare
+    .split(',')
+    .map(e => e.trim())
+    .map(e => `${e}x${e}`)
+    .join(', ');
 } /* }}} */
 
 function conn_log() { /* {{{ */

--- a/connection.js
+++ b/connection.js
@@ -471,7 +471,7 @@ class Connection {
         if (!config.allowed_komi[notification.komi] && !config.allow_all_komi && !config.komiranked && !config.komiunranked) {
             let notificationKomiString = "";
             if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
-                notificationKomiString = "Automatic";
+                notificationKomiString = "automatic";
             } else {
                 notificationKomiString = notification.komi;
             }
@@ -482,7 +482,7 @@ class Connection {
         if (!config.allowed_komi_ranked[notification.komi] && notification.ranked && !config.allow_all_komi_ranked && config.komiranked) {
             let notificationKomiString = "";
             if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
-                notificationKomiString = "Automatic";
+                notificationKomiString = "automatic";
             } else {
                 notificationKomiString = notification.komi;
             }
@@ -493,7 +493,7 @@ class Connection {
         if (!config.allowed_komi_unranked[notification.komi] && !notification.ranked && !config.allow_all_komi_unranked && config.komiunranked) {
             let notificationKomiString = "";
             if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
-                notificationKomiString = "Automatic";
+                notificationKomiString = "automatic";
             } else {
                 notificationKomiString = notification.komi;
             }

--- a/connection.js
+++ b/connection.js
@@ -336,19 +336,6 @@ class Connection {
             return { reject: true, msg: "The " + notification.rules + " rules are not allowed for this bot, please choose allowed rules such as chinese rules. " };
         }
 
-        // for all the allowed_family options ranked and unranked options below 
-        // (timecontrols, speeds, komi, boardsizes)
-        // we need to add a "family guard" :
-        // - && config.familyranked for ranked games 
-        // - && config.familyunranked for unranked games
-        // else the allowed_ is always false and always rejects
-
-        // note : "absolute" and/or "none" are possible, but not in defaults, see README and OPTIONS-LIST for details
-        if (!config.allowed_timecontrols[t.time_control] && !config.timecontrolranked && !config.timecontrolunranked) { 
-            conn_log(user.username + " wanted time control " + t.time_control + ", not in: " + config.timecontrol);
-            return { reject: true, msg: "The " + t.time_control + " time control is not allowed on this bot, please choose one of these allowed time controls on this bot : " + config.timecontrol };
-        }
-
         if (config.rankedonly && !notification.ranked) {
             conn_log("Ranked games only");
             return { reject: true, msg: "This bot accepts ranked games only. " };
@@ -358,6 +345,12 @@ class Connection {
             conn_log("Unranked games only");
             return { reject: true, msg: "This bot accepts Unranked games only. " };
         }
+
+        // for all the allowed_family options below (timecontrols, speeds, komi, boardsizes) 
+        // we need to add a "family guard" 
+        // && config.familyranked for ranked games 
+        // && config.familyunranked for unranked games
+        // else the allowed_ is always false and always rejects
 
         /******** begining of BOARDSIZES *********/
         // for square board sizes only //
@@ -510,22 +503,33 @@ class Connection {
 
         if (!config.allowed_speeds[t.speed] && !config.speedranked && !config.speedunranked) {
             conn_log(user.username + " wanted speed " + t.speed + ", not in: " + config.speed);
-            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot, please choose one of these allowed game speeds on this bot : " + config.speed };
+            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot, please choose one of these allowed game speeds on this bot : " + config.speed};
         }
 
         if (!config.allowed_speeds_ranked[t.speed] && notification.ranked && config.speedranked) {
             conn_log(user.username + " wanted speed for ranked games " + t.speed + ", not in: " + config.speedranked);
-            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot for ranked games, please choose one of these allowed game speeds for ranked games : " + config.speedranked };
+            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot for ranked games, please choose one of these allowed game speeds for ranked games : " + config.speedranked};
         }
 
         if (!config.allowed_speeds_unranked[t.speed] && !notification.ranked && config.speedunranked) {
             conn_log(user.username + " wanted speed for unranked games " + t.speed + ", not in: " + config.speedunranked);
-            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot for unranked games, please choose one of these allowed game speeds for unranked games : " + config.speedunranked };
+            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot for unranked games, please choose one of these allowed game speeds for unranked games : " + config.speedunranked};
         }
 
-        if (!config.allowed_timecontrols[t.time_control]) {
+        // note : "absolute" and/or "none" are possible, but not in defaults, see README and OPTIONS-LIST for details
+        if (!config.allowed_timecontrols[t.time_control] && !config.timecontrolranked && !config.timecontrolunranked) { 
             conn_log(user.username + " wanted time control " + t.time_control + ", not in: " + config.timecontrol);
-            return { reject: true, msg: "The " + t.time_control + " time control is not allowed, please choose one of these allowed time controls : " + config.timecontrol };
+            return { reject: true, msg: "The " + t.time_control + " time control is not allowed on this bot, please choose one of these allowed time controls on this bot : " + config.timecontrol };
+        }
+
+        if (!config.allowed_timecontrols_ranked[t.time_control] && notification.ranked && config.timecontrolranked) { 
+            conn_log(user.username + " wanted time control for ranked games " + t.time_control + ", not in: " + config.timecontrolranked);
+            return { reject: true, msg: "The " + t.time_control + " time control is not allowed on this bot for ranked games, please choose one of these allowed time controls for ranked games : " + config.timecontrolranked };
+        }
+
+        if (!config.allowed_timecontrols_unranked[t.time_control] && !notification.ranked && config.timecontrolunranked) { 
+            conn_log(user.username + " wanted time control for unranked games " + t.time_control + ", not in: " + config.timecontrolunranked);
+            return { reject: true, msg: "The " + t.time_control + " time control is not allowed on this bot for unranked games, please choose one of these allowed time controls for unranked games : " + config.timecontrolunranked };
         }
 
         ////// begining of *** UHMAEAT v2.2: Universal Highly Modulable And Expandable Argv Tree ***

--- a/connection.js
+++ b/connection.js
@@ -420,8 +420,14 @@ class Connection {
         }
 
         if (!config.allowed_komi[notification.komi] && !config.allow_all_komi) {
-            conn_log("komi value " + notification.komi + " is not an allowed komi, allowed komi are: " + config.komi + ", rejecting challenge");
-            return { reject: true, msg: "komi " + notification.komi + " is not an allowed komi, please choose one of these allowed komi : " + config.komi };
+            let notificationKomiString = "";
+            if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
+                notificationKomiString = "Automatic";
+            } else {
+                notificationKomiString = notification.komi;
+            }
+            conn_log("komi value " + notificationKomiString + " is not allowed, allowed komi are: " + config.komi);
+            return { reject: true, msg: "komi " + notificationKomiString + " is not allowed, please choose one of these allowed komi : " + config.komi};
         }
 
         if (!config.allowed_speeds[t.speed]) {

--- a/connection.js
+++ b/connection.js
@@ -475,7 +475,7 @@ class Connection {
             return { reject: true, msg: "Maximum handicap for unranked games is " + config.maxhandicapunranked + " , please increase the number of handicap stones" };
         }
 
-        if (!config.allowed_komi[notification.komi] && !config.allow_all_komi) {
+        if (!config.allowed_komi[notification.komi] && !config.allow_all_komi && !config.komiranked && !config.komiunranked) {
             let notificationKomiString = "";
             if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
                 notificationKomiString = "Automatic";
@@ -484,6 +484,28 @@ class Connection {
             }
             conn_log("komi value " + notificationKomiString + " is not allowed, allowed komi are: " + config.komi);
             return { reject: true, msg: "komi " + notificationKomiString + " is not allowed, please choose one of these allowed komi : " + config.komi};
+        }
+
+        if (!config.allowed_komi_ranked[notification.komi] && notification.ranked && !config.allow_all_komi_ranked && config.komiranked) {
+            let notificationKomiString = "";
+            if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
+                notificationKomiString = "Automatic";
+            } else {
+                notificationKomiString = notification.komi;
+            }
+            conn_log("komi value " + notificationKomiString + " is not allowed for ranked games, allowed komi for ranked games are: " + config.komiranked);
+            return { reject: true, msg: "komi " + notificationKomiString + " is not allowed for ranked games, please choose one of these allowed komi for ranked games: " + config.komiranked};
+        }
+
+        if (!config.allowed_komi_unranked[notification.komi] && !notification.ranked && !config.allow_all_komi_unranked && config.komiunranked) {
+            let notificationKomiString = "";
+            if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
+                notificationKomiString = "Automatic";
+            } else {
+                notificationKomiString = notification.komi;
+            }
+            conn_log("komi value " + notificationKomiString + " is not allowed for unranked games, allowed komi for unranked games are: " + config.komiunranked);
+            return { reject: true, msg: "komi " + notificationKomiString + " is not allowed for unranked games, please choose one of these allowed komi for unranked games: " + config.komiunranked};
         }
 
         if (!config.allowed_speeds[t.speed]) {

--- a/connection.js
+++ b/connection.js
@@ -508,9 +508,19 @@ class Connection {
             return { reject: true, msg: "komi " + notificationKomiString + " is not allowed for unranked games, please choose one of these allowed komi for unranked games: " + config.komiunranked};
         }
 
-        if (!config.allowed_speeds[t.speed]) {
+        if (!config.allowed_speeds[t.speed] && !config.speedranked && !config.speedunranked) {
             conn_log(user.username + " wanted speed " + t.speed + ", not in: " + config.speed);
-            return { reject: true, msg: "The " + t.speed + " game speed is not allowed, please choose one of these allowed game speeds : " + config.speed };
+            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot, please choose one of these allowed game speeds on this bot : " + config.speed };
+        }
+
+        if (!config.allowed_speeds_ranked[t.speed] && notification.ranked && config.speedranked) {
+            conn_log(user.username + " wanted speed for ranked games " + t.speed + ", not in: " + config.speedranked);
+            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot for ranked games, please choose one of these allowed game speeds for ranked games : " + config.speedranked };
+        }
+
+        if (!config.allowed_speeds_unranked[t.speed] && !notification.ranked && config.speedunranked) {
+            conn_log(user.username + " wanted speed for unranked games " + t.speed + ", not in: " + config.speedunranked);
+            return { reject: true, msg: "The " + t.speed + " game speed is not allowed on this bot for unranked games, please choose one of these allowed game speeds for unranked games : " + config.speedunranked };
         }
 
         if (!config.allowed_timecontrols[t.time_control]) {

--- a/connection.js
+++ b/connection.js
@@ -372,19 +372,19 @@ class Connection {
 
         /* if square, check if square board size is allowed*/
         if (!config.allowed_sizes[notification.width] && !config.allow_all_sizes && !config.allow_custom_sizes && !config.boardsizeranked && !config.boardsizeunranked) {
-            let boardsizeSquareString = String(config.boardsize); // we convert the value to a string to avoid undefined error later
+            let boardsizeSquareString = config.boardsize;
             conn_log("square board size " + notification.width + "x" + notification.height + " is not an allowed size");
             return { reject: true, msg: "Board size " + notification.width + "x" + notification.height + " is not allowed, please choose one of these allowed board sizes " + boardsizeSquareToDisplayString(boardsizeSquareString)};
         }
 
         if (!config.allowed_sizes_ranked[notification.width] && !config.allow_all_sizes_ranked && !config.allow_custom_sizes_ranked && notification.ranked && config.boardsizeranked) {
-            let boardsizeSquareString = String(config.boardsizeranked); // we convert the value to a string to avoid undefined error later
+            let boardsizeSquareString = config.boardsizeranked;
             conn_log("square board size " + notification.width + "x" + notification.height + " is not an allowed size for ranked games");
             return { reject: true, msg: "Board size " + notification.width + "x" + notification.height + " is not allowed for ranked games, please choose one of these allowed board sizes for ranked games : " + boardsizeSquareToDisplayString(boardsizeSquareString)};
         }
 
         if (!config.allowed_sizes_unranked[notification.width] && !config.allow_all_sizes_unranked && !config.allow_custom_sizes_unranked && !notification.ranked  && config.boardsizeunranked) {
-            let boardsizeSquareString = String(config.boardsizeunranked); // we convert the value to a string to avoid undefined error later
+            let boardsizeSquareString = config.boardsizeunranked;
             conn_log("square board size " + notification.width + "x" + notification.height + " is not an allowed size for unranked games");
             return { reject: true, msg: "Board size " + notification.width + "x" + notification.height + " is not allowed for unranked games, please choose one of these allowed board sizes for unranked games " + boardsizeSquareToDisplayString(boardsizeSquareString)};
         }
@@ -470,7 +470,7 @@ class Connection {
 
         if (!config.allowed_komi[notification.komi] && !config.allow_all_komi && !config.komiranked && !config.komiunranked) {
             let notificationKomiString = "";
-            if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
+            if (notification.komi === null) {
                 notificationKomiString = "automatic";
             } else {
                 notificationKomiString = notification.komi;
@@ -481,7 +481,7 @@ class Connection {
 
         if (!config.allowed_komi_ranked[notification.komi] && notification.ranked && !config.allow_all_komi_ranked && config.komiranked) {
             let notificationKomiString = "";
-            if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
+            if (notification.komi === null) {
                 notificationKomiString = "automatic";
             } else {
                 notificationKomiString = notification.komi;
@@ -492,7 +492,7 @@ class Connection {
 
         if (!config.allowed_komi_unranked[notification.komi] && !notification.ranked && !config.allow_all_komi_unranked && config.komiunranked) {
             let notificationKomiString = "";
-            if (String(notification.komi) === "null") { // we need to declare this as a string or the test fails
+            if (notification.komi === null) {
                 notificationKomiString = "automatic";
             } else {
                 notificationKomiString = notification.komi;

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -120,17 +120,17 @@ Allows custom board sizes 25x1 25x2 25x3 in that example, see
 [notes E-](/docs/docs/NOTES.md#e-) for details
 
 #### komi 
-```--komi``` Allowed komi values  (default Automatic)
+```--komi``` Allowed komi values  (default automatic)
 
 ```--komiranked``` Allowed komi values for ranked games
 
 ```--komiunranked``` Allowed komi values for unranked games
  
 Possible komi values : 
-- `Automatic` (allows Automatic komi), 
+- `automatic` (allows automatic komi), 
 - `all` (allows all komi values), When `all` is used alone, all 
 komi values are allowed. 
-- comma separated values, for example `7.5`, or `7.5,6.5,0.5,Automatic` 
+- comma separated values, for example `7.5`, or `7.5,6.5,0.5,automatic` 
 
 When an argument other than `all` is used, only the chosen argument komi 
 values are allowed and all other komi values are rejected see 


### PR DESCRIPTION
general look here : https://github.com/wonderingabout/gtp2ogs/tree/komi-Automatic-boardsize-humanreadable-speedtimecontrolranked

2 main changes as detailed in commit messages : 

1- display komi and boardsize in human readable 
in reject messages : 
- notification.komi "null" -> "Automatic"
- this change requires to rename `--komi auto` to 
`--komi automatic` for display consistency (added 
an array detection warning for depreciated feature 
"auto") @windo 
- display boardsize in human readable : `9,13,19`
-> `9x9, 13x13, 19x19`, `9` -> `9x9`, credit goes to 
@Dorus for making this code, i only included it in 
a function

2A- add : 
--boardsizeranked
--boardsizeunranked
--komiranked
--komiunranked
--speedranked
--speedunranked
--timecontrolranked
--timecontrolunranked

as explained in commit message, this can be useful 
for example : 
-  if bot admin is open to allow correspondence 
games, but only in unranked, 
- and/or the same for "absolute", 
- and/or the same for 9x9 and 13x13 if the bot is playable on 
other boardsizes but less reliable, 
- and/or the same for komi ranked naturally, because 
komi is a function of boardsize (different values if 
boardsize is different) 

2B- for the "allowed_" family (boardsize,komi, speed, 
timecontrols), added a family guard for ranked and 
unranked versions of the option, else the "allowed_" 
is always false and game is always rejected

some minor fixes here and there too

read commit messages for details and explanations

@roy7 @anoek @Dorus 

this is the last chunk of my old big PR in #129, i hope i 
didnt forget anything from that branch