### PR TITLE
support showboard again, optionally enablable with --showboard

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -379,8 +379,9 @@ class Bot {
 
             color = color == 'black' ? 'white' : 'black';
         }
-        // This breaks PhoenixGo.
-        //this.command("showboard", cb, eb);
+        if (config.SHOWBOARD) {
+            this.command("showboard", cb, eb);
+        }
         return true;
     } /* }}} */
 

--- a/config.js
+++ b/config.js
@@ -6,6 +6,7 @@ let console = require('console');
 exports.DEBUG = false;
 exports.PERSIST = false;
 exports.KGSTIME = false;
+exports.SHOWBOARD = false;
 exports.NOCLOCK = false;
 exports.GREETING = "";
 exports.FAREWELL = "";
@@ -64,6 +65,7 @@ exports.updateFromArgv = function() {
         .describe('logfile', 'In addition to logging to the console, also log gtp2ogs output to a text file')
         .describe('json', 'Send and receive GTP commands in a JSON encoded format')
         .describe('kgstime', 'Set this if bot understands the kgs-time_settings command')
+        .describe('showboard', 'Set this if bot understands the showboard GTP command, and if you want to display the showboard output')
         .describe('noclock', 'Do not send any clock/time data to the bot')
         .describe('persist', 'Bot process remains running between moves')
         .describe('corrqueue', 'Process correspondence games one at a time')
@@ -373,6 +375,10 @@ exports.updateFromArgv = function() {
     // TODO: Test known_commands for kgs-time_settings to set this, and remove the command line option
     if (argv.kgstime) {
         exports.KGSTIME = true;
+    }
+
+    if (argv.showboard) {
+        exports.SHOWBOARD = true;
     }
 
     if (argv.noclock) {

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -21,8 +21,9 @@ link to the wanted option :
 ```--insecure```  Don't use ssl to connect to the ggs/rest servers
 
 #### beta
-```--beta```  Connect to the [beta server](https://beta.online-go.com/) instead of 
-[OGS](https://online-go.com/) (sets ggs/rest hosts to the beta server)
+```--beta```  Connect to the [beta server](https://beta.online-go.com/) 
+instead of [OGS](https://online-go.com/) (sets ggs/rest hosts to the 
+beta server)
 
 #### debug
 ```--debug```  Output GTP command and responses from your Go engine
@@ -36,6 +37,15 @@ output to a text file
 
 #### kgstime
   ```--kgstime```  Set this if bot understands the kgs-time_settings command
+
+#### showboard
+  ```--showboard```  Set this if bot understands the showboard GTP command, 
+and if you want to display the showboard output
+
+- This breaks some bots which dont support it 
+- And this makes the log much bigger, so may not be desired even if supported
+
+So default is disabled
 
 #### noclock
   ```--noclock``` Do not send any clock/time data to the bot


### PR DESCRIPTION
@roy7 @Dorus @windo 

general look here : https://github.com/wonderingabout/gtp2ogs/tree/config-showboard

showboard support was removed in :
https://github.com/online-go/gtp2ogs/commit/d5ebdbbde259a97c5ae1aed0ec42a07c9fbb2dbf

this was because some bots dont support it and it breaks them (for example
PhoenixGo),

adding optional support for it again : 
to enable support for GTP command showboard, use the
gtp2ogs argument `--showboard` (which is config.SHOWBOARD)

also, some bot admins may want to disable it for smaller
and easier to read log, so giving the option to enable it or 
not is also useful in that case

so supporting this again but default is disabled

didnt test it (my main bot is PhoenixGo), but i hope it 
should work without any issue