### PR TITLE
eslint: require eqeqeq

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,11 @@
+env:
+  node: true
+  es6: true
+globals:
+  Atomics: readonly
+  SharedArrayBuffer: readonly
+parserOptions:
+  ecmaVersion: 2018
+  sourceType: module
+rules:
+  eqeqeq: ["error", "smart"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
   - "node"
+
+script:
+  - "npm run lint"
+  - "npm test"

--- a/connection.js
+++ b/connection.js
@@ -212,7 +212,7 @@ class Connection {
                 continue;
             }
             let idle_time = now - state.clock.last_move;
-            if ((state.clock.current_player != this.bot_id) && (idle_time > config.timeout)) {
+            if ((state.clock.current_player !== this.bot_id) && (idle_time > config.timeout)) {
                 if (config.DEBUG) conn_log("Found idle game", game_id, ", other player has been idling for", idle_time, ">", config.timeout);
                 this.disconnectFromGame(game_id);
             }
@@ -354,17 +354,17 @@ class Connection {
         /******** begining of BOARDSIZES *********/
         // for square board sizes only //
         /* if not square*/
-        if (notification.width != notification.height && !config.allow_all_sizes && !config.allow_custom_sizes && !config.boardsizeranked && !config.boardsizeunranked) {
+        if (notification.width !== notification.height && !config.allow_all_sizes && !config.allow_custom_sizes && !config.boardsizeranked && !config.boardsizeunranked) {
             conn_log("board was not square, not allowed");
             return { reject: true, msg: "Your selected board size " + notification.width + "x" + notification.height + " (width x height), is not square, not allowed, please choose a square board size (same width and height, for example 9x9 or 19x19). " };
         }
 
-        if (notification.width != notification.height && !config.allow_all_sizes_ranked && !config.allow_custom_sizes_ranked && notification.ranked) {
+        if (notification.width !== notification.height && !config.allow_all_sizes_ranked && !config.allow_custom_sizes_ranked && notification.ranked) {
             conn_log("board was not square, not allowed for ranked games");
             return { reject: true, msg: "Your selected board size " + notification.width + "x" + notification.height + " (width x height), is not square, not allowed for ranked games, please choose a square board size (same width and height, for example 9x9 or 19x19). " };
         }
 
-        if (notification.width != notification.height && !config.allow_all_sizes_unranked && !config.allow_custom_sizes_unranked && !notification.ranked) {
+        if (notification.width !== notification.height && !config.allow_all_sizes_unranked && !config.allow_custom_sizes_unranked && !notification.ranked) {
             conn_log("board was not square, not allowed for unranked games");
             return { reject: true, msg: "Your selected board size " + notification.width + "x" + notification.height + " (width x height), is not square, not allowed for unranked games, please choose a square board size (same width and height, for example 9x9 or 19x19). " };
         }
@@ -1568,7 +1568,7 @@ class Connection {
             this.games_by_player[player] = [ game_id ];
             return;
         }
-        if (this.games_by_player[player].indexOf(game_id) != -1)  // Already have it ?
+        if (this.games_by_player[player].indexOf(game_id) !== -1)  // Already have it ?
             return;
         this.games_by_player[player].push(game_id);
     } /* }}} */

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "tracer": "=0.8.7"
   },
   "devDependencies": {
+    "eslint": "5.14.1",
     "mocha": "5.2.0",
     "sinon": "7.2.3"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "lint": "eslint \"./**/*.js\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I just created a plain eslint config that currently just enforces
eqeqeq. We can add other coding conventions as specific rules into the
config later.

In particular, we should probably enable the `eslint:recommended` base
configuration that enables quite a few common options:

https://eslint.org/docs/rules/

But can't do it right off the bat because that requires a few more
cleanups before it would run cleanly on the codebase.