### PR TITLE
only connect to games during bot turn

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -162,8 +162,11 @@ class Connection {
             if (gamedata.phase === "finished" && !(gamedata.id in this.connected_games))
                 return;
 
+            // Don't connect if it is not our turn.
+            if (gamedata.player_to_move !== this.bot_id)
+                return;
+
             // Set up the game so it can listen for events.
-            //
             this.connectToGame(gamedata.id);
 
             // When a game ends, we don't get a "finished" active_game.phase. Probably since the game is no


### PR DESCRIPTION
I had a little meltdown of my bots (and the machine they are running on) today when both of the bots disconnected and then reconnected to the server at the same time and tried restarting all the bots, which failed and then it kept on trying to recover but was stuck in a loop of some sort and not being able to clean up all the old bots nor start new ones.

I don't think this PR necessarily helps with it directly (it might - there was a lot of trying to connect to games over and over going on in the logs), but it's a challenge to even understand what's going on from the logs with all the connections to the games that are idling.

Tested against beta server - starting `gtp2ogs` during human turn and then making a move as human woke the bot up as expected. Starting it during bot turn made the bot immediately move.