### PR TITLE
documentation updates for npm install from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,38 @@ This step is **is recommended**
 By default, npm installs an old branch of gtp2ogs that does not include latest 
 improvements, new features, and fixes
 
-To upgrade to devel branch (newest), see :
+An easy way to upgrade is to copy all the devel gtp2ogs files and folders 
+(bot.js, config.js, etc..) to the original directory where gtp2ogs is 
+installed, and overwrite the old existing files 
+
+note : before overwriting, you can backup your old files so that you can 
+go back to the old branch of gtp2ogs anytime later if you want
+
+Then it is needed to do the post install :
+
+The command below will automatically detect all missing packages needed 
+from the package.json of the new branch, and install all these packages
+
+- for linux :
+
+```
+cd /usr/lib/node_modules/gtp2ogs/
+sudo npm install
+```
+
+- for windows :
+
+Open a node.js command prompt as admin, then :
+
+```
+pushd C:\Users\yourwindowsusername\AppData\Roaming\npm\node_modules\gtp2ogs\
+npm install
+```
+
+For details or help, you can see :
 
 - for linux : [3A3) Recommended : Upgrade gtp2ogs.js from old branch to “devel” branch (latest)](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3A3-linux-optional-upgrade-to-devel.md)
 - for windows : [3B3) Recommended : Upgrade gtp2ogs from old branch to devel (latest) branch](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3B3-windows-optional-upgrade-to-devel.md)
-
-When you upgrade you need to copy all the gtp2ogs files (bot.js, config.js, etc..) 
-and overwrite the old files (you can backup your old files so that you can go back 
-to the old version if you want later)
 
 ### 4. Most common usage : start gtp2ogs.js using nodejs
 
@@ -102,20 +126,6 @@ you want
   
 note 3 : to play on [beta OGS server](https://beta.online-go.com/) instead of the 
 [OGS server](https://online-go.com/), add the `--beta` argument
-
-### 5. Optional : install any missing node.js packages
-
-**This step can be skipped unless you have issues or bugs**
-
-You may need to install some missing packages if the 
-[Most common usage](#4-most-common-usage--start-gtp2ogsjs-using-nodejs) fails
-
-To do that, you can just run (as admin on windows, as sudo on linux) :
-
-```npm install```
-
-This command will automatically detect all missing packages needed 
-from package.json and install them
 
 ### Extra : add features by editing gtp2ogs files
 

--- a/docs/CUSTOM-BRANCHES.md
+++ b/docs/CUSTOM-BRANCHES.md
@@ -1,9 +1,21 @@
 Some custom branches are very helpful for gtp2ogs, but they are not implemented 
 in the official gtp2ogs because it would add extra maintainance to maintain them
 
-To use them, just replace your current gtp2ogs files with the branche's file, 
-as explained in the gtp2ogs full tutorial, except that you have to download the 
-custom branch ZIP instead of the devel branch : 
+# How to test a custom gtp2ogs branch
+
+To use them, just replace your current gtp2ogs files with the branch's file
+
+It is in fact the same methodology than for upgrading to devel, except that you 
+upgrade to another custom branch from another owner
+
+Refer to the general steps here : 
+[3. Recommended : Upgrade to devel branch](/README.md/#3-recommended--upgrade-to-devel-branch)
+
+except that you have to replace `-b devel online-go/gtp2ogs` with 
+`-b custombranchname customowner`
+
+If it is not clear, you can also see the gtp2ogs full tutorial, except that 
+you have to download the custom branch ZIP instead of the devel branch : 
 - for linux : [3A3) Recommended : Upgrade gtp2ogs.js from old branch to “devel” branch (latest)](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3A3-linux-optional-upgrade-to-devel.md)
 - for windows : [3B3) Recommended : Upgrade gtp2ogs from old branch to devel (latest) branch](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3B3-windows-optional-upgrade-to-devel.md)
 


### PR DESCRIPTION
@anoek @roy7 @Dorus @windo 

`npm install` was indeed enough to install all needed
packages from the provided package.json, as @Dorus 
explained
(run as sudo for linux, or admin for windows)

in my test, eslint, mocha, and co, were all succesfully
detected and installed with npm install (need to cd
to gtp2ogs directory first)

also see screenshots included in the PR for examples

![npminstall](https://user-images.githubusercontent.com/38690718/53680264-310cc100-3cd9-11e9-8e00-ab96a69b5db8.png)

![npminstall2](https://user-images.githubusercontent.com/38690718/53680263-310cc100-3cd9-11e9-8534-92d40e53e251.png)

in this example, i am upgrading from the installed gtp2ogs 5.3, 
so it is expected to see many packages installed

therefore, the optional steps to install optimist in case of error
are also not needed anymore : npm install will do that
too