### PR TITLE
Disconnect game in gameOver()

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -41,7 +41,6 @@ class Connection {
         this.connected_games = {};
         this.games_by_player = {};     // Keep track of connected games per player
         this.connected = false;
-        this.disconnect_timeout = null;
 
         this.connect_timeout = setTimeout(()=>{
             if (!this.connected) {
@@ -173,9 +172,10 @@ class Connection {
                 //     on server side: sometimes /gamedata event with game outcome is sent after
                 //     active_game, so it's lost since there's no game to handle it anymore...
                 //     Work around it with a timeout for now.
-                if (!this.disconnect_timeout) {
+                if (!this.connected_games[gamedata.id].disconnect_timeout) {
                     console.log("Starting disconnect Timeout in Connection active_game for " + gamedata.id);
-                    this.disconnect_timeout = setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
+                    this.connected_games[gamedata.id].disconnect_timeout =
+                        setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
                 }
             }
 
@@ -1648,7 +1648,6 @@ class Connection {
     }}}
     terminate() {{{
         clearTimeout(this.connect_timeout);
-        clearTimeout(this.disconnect_timeout);
         clearInterval(this.ping_interval);
         clearInterval(this.notification_connect_interval);
         clearInterval(this.corr_queue_interval);

--- a/connection.js
+++ b/connection.js
@@ -173,7 +173,10 @@ class Connection {
                 //     on server side: sometimes /gamedata event with game outcome is sent after
                 //     active_game, so it's lost since there's no game to handle it anymore...
                 //     Work around it with a timeout for now.
-                if (!this.disconnect_timeout) this.disconnect_timeout = setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
+                if (!this.disconnect_timeout) {
+                    console.log("Starting disconnect Timeout in Connection active_game for " + gamedata.id);
+                    this.disconnect_timeout = setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
+                }
             }
 
             // Don't connect if it is not our turn.

--- a/connection.js
+++ b/connection.js
@@ -41,6 +41,7 @@ class Connection {
         this.connected_games = {};
         this.games_by_player = {};     // Keep track of connected games per player
         this.connected = false;
+        this.disconnect_timeout = null;
 
         this.connect_timeout = setTimeout(()=>{
             if (!this.connected) {
@@ -179,7 +180,7 @@ class Connection {
                 //     on server side: sometimes /gamedata event with game outcome is sent after
                 //     active_game, so it's lost since there's no game to handle it anymore...
                 //     Work around it with a timeout for now.
-                setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
+                if (!this.disconnect_timeout) this.disconnect_timeout = setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
             }
         });
     }}}

--- a/connection.js
+++ b/connection.js
@@ -1645,6 +1645,7 @@ class Connection {
     }}}
     terminate() {{{
         clearTimeout(this.connect_timeout);
+        clearTimeout(this.disconnect_timeout);
         clearInterval(this.ping_interval);
         clearInterval(this.notification_connect_interval);
         clearInterval(this.corr_queue_interval);

--- a/connection.js
+++ b/connection.js
@@ -158,24 +158,26 @@ class Connection {
                 this.processMove(gamedata);
             } */
 
-            // Don't connect to old finished games.
-            if (gamedata.phase === "finished" && !(gamedata.id in this.connected_games))
-                return;
-
-            // When a game ends, we don't get a "finished" active_game.phase. Probably since the game is no
-            // longer active.(Update: We do get finished active_game events? Unclear why I added prior note.)
-            //
             if (gamedata.phase === "finished") {
-                if (config.DEBUG) conn_log(gamedata.id, "gamedata.phase === finished");
+                if (!(gamedata.id in this.connected_games)) {
+                    // Don't connect to old finished games.
+                    return;
+                } else {
+                    // When a game ends, we don't get a "finished" active_game.phase. Probably since the game is no
+                    // longer active.(Update: We do get finished active_game events? Unclear why I added prior note.)
+                    // Note: active_game and gamedata events can arrive in either order.
+                    //
+                    if (config.DEBUG) conn_log(gamedata.id, "active_game phase === finished");
 
-                // XXX We want to disconnect right away here, but there's a game over race condition
-                //     on server side: sometimes /gamedata event with game outcome is sent after
-                //     active_game, so it's lost since there's no game to handle it anymore...
-                //     Work around it with a timeout for now.
-                if (!this.connected_games[gamedata.id].disconnect_timeout) {
-                    console.log("Starting disconnect Timeout in Connection active_game for " + gamedata.id);
-                    this.connected_games[gamedata.id].disconnect_timeout =
-                        setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
+                    // XXX We want to disconnect right away here, but there's a game over race condition
+                    //     on server side: sometimes /gamedata event with game outcome is sent after
+                    //     active_game, so it's lost since there's no game to handle it anymore...
+                    //     Work around it with a timeout for now.
+                    if (!this.connected_games[gamedata.id].disconnect_timeout) {
+                        if (config.DEBUG) console.log("Starting disconnect Timeout in Connection active_game for " + gamedata.id);
+                        this.connected_games[gamedata.id].disconnect_timeout =
+                            setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
+                    }
                 }
             }
 

--- a/connection.js
+++ b/connection.js
@@ -159,10 +159,7 @@ class Connection {
             } */
 
             if (gamedata.phase === "finished") {
-                if (!(gamedata.id in this.connected_games)) {
-                    // Don't connect to old finished games.
-                    return;
-                } else {
+                if (gamedata.id in this.connected_games) {
                     // When a game ends, we don't get a "finished" active_game.phase. Probably since the game is no
                     // longer active.(Update: We do get finished active_game events? Unclear why I added prior note.)
                     // Note: active_game and gamedata events can arrive in either order.
@@ -179,6 +176,9 @@ class Connection {
                             setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
                     }
                 }
+
+                // Don't connect to finished games.
+                return;
             }
 
             // Don't connect if it is not our turn.

--- a/connection.js
+++ b/connection.js
@@ -163,13 +163,6 @@ class Connection {
             if (gamedata.phase === "finished" && !(gamedata.id in this.connected_games))
                 return;
 
-            // Don't connect if it is not our turn.
-            if (gamedata.player_to_move !== this.bot_id)
-                return;
-
-            // Set up the game so it can listen for events.
-            this.connectToGame(gamedata.id);
-
             // When a game ends, we don't get a "finished" active_game.phase. Probably since the game is no
             // longer active.(Update: We do get finished active_game events? Unclear why I added prior note.)
             //
@@ -182,6 +175,13 @@ class Connection {
                 //     Work around it with a timeout for now.
                 if (!this.disconnect_timeout) this.disconnect_timeout = setTimeout(() => {  this.disconnectFromGame(gamedata.id);  }, 1000);
             }
+
+            // Don't connect if it is not our turn.
+            if (gamedata.player_to_move !== this.bot_id)
+                return;
+
+            // Set up the game so it can listen for events.
+            this.connectToGame(gamedata.id);
         });
     }}}
     auth(obj) { /* {{{ */

--- a/game.js
+++ b/game.js
@@ -454,7 +454,7 @@ class Game {
             this.ensureBotKilled();
         }
 
-        setTimeout(() => {  this.conn.disconnectFromGame(gamedata.id);  }, 1000);
+        setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
     } /* }}} */
     header() { /* {{{ */
         if (!this.state)  return;

--- a/game.js
+++ b/game.js
@@ -454,7 +454,7 @@ class Game {
             this.ensureBotKilled();
         }
 
-        setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
+        if (!this.conn.disconnect_timeout) this.conn.disconnect_timeout = setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
     } /* }}} */
     header() { /* {{{ */
         if (!this.state)  return;

--- a/game.js
+++ b/game.js
@@ -456,7 +456,7 @@ class Game {
         }
 
         if (!this.disconnect_timeout) {
-            console.log("Starting disconnect Timeout in Game " + this.game_id + " gameOver()");
+            if (config.DEBUG) console.log("Starting disconnect Timeout in Game " + this.game_id + " gameOver()");
             this.disconnect_timeout = setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
         }
     } /* }}} */

--- a/game.js
+++ b/game.js
@@ -26,6 +26,7 @@ class Game {
         this.corr_move_pending = false;
         this.processing = false;
         this.handicap_moves = [];    // Handicap stones waiting to be sent when bot is playing black.
+        this.disconnect_timeout = null;
 
         this.scheduleRetry = this.scheduleRetry.bind(this);
 
@@ -454,9 +455,9 @@ class Game {
             this.ensureBotKilled();
         }
 
-        if (!this.conn.disconnect_timeout) {
+        if (!this.disconnect_timeout) {
             console.log("Starting disconnect Timeout in Game " + this.game_id + " gameOver()");
-            this.conn.disconnect_timeout = setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
+            this.disconnect_timeout = setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
         }
     } /* }}} */
     header() { /* {{{ */

--- a/game.js
+++ b/game.js
@@ -454,7 +454,10 @@ class Game {
             this.ensureBotKilled();
         }
 
-        if (!this.conn.disconnect_timeout) this.conn.disconnect_timeout = setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
+        if (!this.conn.disconnect_timeout) {
+            console.log("Starting disconnect Timeout in Game " + this.game_id + " gameOver()");
+            this.conn.disconnect_timeout = setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
+        }
     } /* }}} */
     header() { /* {{{ */
         if (!this.state)  return;

--- a/game.js
+++ b/game.js
@@ -453,6 +453,8 @@ class Game {
             this.bot.gameOver();
             this.ensureBotKilled();
         }
+
+        setTimeout(() => {  this.conn.disconnectFromGame(gamedata.id);  }, 1000);
     } /* }}} */
     header() { /* {{{ */
         if (!this.state)  return;


### PR DESCRIPTION
Can this cause a race condition if active_game does arrive after gamedata, where we try to disconnect twice? If we have already disconnected, will the timeout here crash with an undefined error? Do we actually need more like

setTimeout(() => {  if (this && this.conn) this.conn.disconnectFromGame(gamedata.id);  }, 1000);

or similar? Or store the disconnecting timeout in the conn object and test for it so we don't set the timer a second time? Like a this.conn.shuttingdown.