### PR TITLE
add --colorseven --colorshandicap +/- ranked/unranked (needs server support)

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,6 +39,12 @@ exports.allow_all_komis_ranked = false;
 exports.allowed_komis_ranked = [];
 exports.allow_all_komis_unranked = false;
 exports.allowed_komis_unranked = [];
+exports.allowed_colors_even = {};
+exports.allowed_colors_even_ranked = {};
+exports.allowed_colors_even_unranked = {};
+exports.allowed_colors_handicap = {};
+exports.allowed_colors_handicap_ranked = {};
+exports.allowed_colors_handicap_unranked = {};
 exports.allowed_speeds = {};
 exports.allowed_speeds_ranked = {};
 exports.allowed_speeds_unranked = {};
@@ -140,6 +146,14 @@ exports.updateFromArgv = function() {
         // make sure to increase minmaintimeblitz and minmaintimelive to high values
         // 2 - "none" is not default, can be manually allowed in timecontrol argument
         // but then games will be very very long
+        .describe('colorseven', 'Opponent color(s) to accept for even (= 0 handicap) games ')
+        .default('colorseven', 'black,white,automatic,random')
+        .describe('colorsevenranked', 'Opponent color(s) to accept for even (= 0 handicap) ranked games')
+        .describe('colorsevenunranked', 'Opponent color(s) to accept for even (= 0 handicap) unranked games')
+        .describe('colorshandicap', 'Opponent color(s) to accept for handicap games')
+        .default('colorshandicap', 'black,white,automatic,random')
+        .describe('colorshandicapranked', 'Opponent color(s) to accept for handicap ranked games')
+        .describe('colorshandicapunranked', 'Opponent color(s) to accept for handicap unranked games')
         .describe('minmaintimeblitz', 'Minimum seconds of main time for blitz ')
         .default('minmaintimeblitz', '15') // 15 seconds
         .describe('maxmaintimeblitz', 'Maximum seconds of main time for blitz ')
@@ -261,7 +275,7 @@ exports.updateFromArgv = function() {
     // console : warnings //
 
     // A - warning : dont use 3 settings of the same family (general, ranked, unranked) at the same time
-    const familyArgs = ["boardsizes", "boardsizewidths", "boardsizeheights", "komis", "speeds", "timecontrols", "minhandicap", "maxhandicap", "noautohandicap", "minmaintimeblitz", "minmaintimelive", "minmaintimecorr", "maxmaintimeblitz", "maxmaintimelive", "maxmaintimecorr", "minperiodsblitz", "minperiodslive", "minperiodscorr", "maxperiodsblitz", "maxperiodslive", "maxperiodscorr", "minperiodtimeblitz", "minperiodtimelive", "minperiodtimecorr", "maxperiodtimeblitz", "maxperiodtimelive", "maxperiodtimecorr", "minrank", "maxrank", "nopause"];
+    const familyArgs = ["boardsizes", "boardsizewidths", "boardsizeheights", "komis", "speeds", "timecontrols", "colorseven", "colorshandicap", "minhandicap", "maxhandicap", "noautohandicap", "minmaintimeblitz", "minmaintimelive", "minmaintimecorr", "maxmaintimeblitz", "maxmaintimelive", "maxmaintimecorr", "minperiodsblitz", "minperiodslive", "minperiodscorr", "maxperiodsblitz", "maxperiodslive", "maxperiodscorr", "minperiodtimeblitz", "minperiodtimelive", "minperiodtimecorr", "maxperiodtimeblitz", "maxperiodtimelive", "maxperiodtimecorr", "minrank", "maxrank", "nopause"];
 // --bans --bansranked --bansunranked are an exception, do not include here
 
     function checkThreeSameTimeFamily() {
@@ -675,6 +689,90 @@ exports.updateFromArgv = function() {
     if (argv.timecontrolsunranked) {
         for (let i of argv.timecontrolunranked.split(',')) {
             exports.allowed_timecontrols_unranked[i] = true;
+        }
+    }
+
+    if (argv.colorseven) {
+        for (let e of argv.colorseven.split(',')) {
+            if (e === "automatic") {
+                exports.allowed_colors_even[-1] = true;
+            }
+            if (e === "random") {
+                exports.allowed_colors_even[null] = true;
+            }
+            if (e === "black" || e === "white") {
+                exports.allowed_colors_even[e] = true;
+            }
+        }
+    }
+
+    if (argv.colorsevenranked) {
+        for (let e of argv.colorsevenranked.split(',')) {
+            if (e === "automatic") {
+                exports.allowed_colors_even_ranked[-1] = true;
+            }
+            if (e === "random") {
+                exports.allowed_colors_even_ranked[null] = true;
+            }
+            if (e === "black" || e === "white") {
+                exports.allowed_colors_even_ranked[e] = true;
+            }
+        }
+    }
+
+    if (argv.colorsevenunranked) {
+        for (let e of argv.colorsevenunranked.split(',')) {
+            if (e === "automatic") {
+                exports.allowed_colors_even_unranked[-1] = true;
+            }
+            if (e === "random") {
+                exports.allowed_colors_even_unranked[null] = true;
+            }
+            if (e === "black" || e === "white") {
+                exports.allowed_colors_even_unranked[e] = true;
+            }
+        }
+    }
+
+    if (argv.colorshandicap) {
+        for (let e of argv.colorshandicap.split(',')) {
+            if (e === "automatic") {
+                exports.allowed_colors_handicap[-1] = true;
+            }
+            if (e === "random") {
+                exports.allowed_colors_handicap[null] = true;
+            }
+            if (e === "black" || e === "white") {
+                exports.allowed_colors_handicap[e] = true;
+            }
+        }
+    }
+
+    if (argv.colorshandicapranked) {
+        for (let e of argv.colorshandicapranked.split(',')) {
+            if (e === "automatic") {
+                exports.allowed_colors_handicap_ranked[-1] = true;
+            }
+            if (e === "random") {
+                exports.allowed_colors_handicap_ranked[null] = true;
+            }
+            if (e === "black" || e === "white") {
+                exports.allowed_colors_handicap_ranked[e] = true;
+            }
+        }
+    }
+
+    if (argv.colorshandicapunranked) {
+        for (let e of argv.colorshandicapunranked.split(',')) {
+            if (e === "automatic") {
+                exports.allowed_colors_handicap_unranked[-1] = true;
+            }
+            if (e === "random") {
+                exports.allowed_colors_handicap_unranked[null] = true;
+            }
+            if (e === "black" || e === "white") {
+                exports.allowed_colors_handicap_unranked[e] = true;
+            }
         }
     }
 

--- a/connection.js
+++ b/connection.js
@@ -382,7 +382,8 @@ class Connection {
             return { reject: true, msg: "This bot accepts Unranked games only. " };
         }
 
-        // for all the allowed_family options below (timecontrols, speeds, komis, boardsizes) 
+        // for all the allowed_family options below 
+        // (boardsizes, komis, colorseven, colorshandicap, speeds, timecontrols) 
         // we need to add a "family guard" 
         // && config.familyranked for ranked games 
         // && config.familyunranked for unranked games
@@ -535,6 +536,36 @@ class Connection {
             }
             conn_log("komi value " + notificationKomiString + " is not allowed for unranked games, allowed komis for unranked games are: " + config.komisunranked);
             return { reject: true, msg: "komi " + notificationKomiString + " is not allowed for unranked games, please choose one of these allowed komis for unranked games: " + config.komisunranked};
+        }
+
+        if (!config.allowed_colors_even[notification.color] && (notification.handicap = 0) && !config.colorsevenranked && !config.colorsevenunranked) {
+            conn_log("opponent color " + notification.color + " is not allowed: " + notification.color + ", allowed colors for even games are :" + config.colorseven);
+            return { reject: true, msg: "color " + notification.color + " is not allowed, please choose one of these allowed colors for even (= 0 handicap) games: " + config.colorseven};
+        }
+
+        if (!config.allowed_colors_even_ranked[notification.color] && (notification.handicap = 0) && notification.ranked && config.colorsevenranked) {
+            conn_log("opponent color " + notification.color + " is not allowed, allowed colors for even ranked games are :" + config.colorsevenranked);
+            return { reject: true, msg: "color " + notification.color + " is not allowed, please choose one of these allowed colors for even (= 0 handicap) ranked games: " + config.colorsevenranked};
+        }
+
+        if (!config.allowed_colors_even_unranked[notification.color] && (notification.handicap = 0) && !notification.ranked && config.colorsevenunranked) {
+            conn_log("opponent color " + notification.color + " is not allowed, allowed colors for even unranked games are :" + config.colorsevenunranked);
+            return { reject: true, msg: "color " + notification.color + " is not allowed, please choose one of these allowed colors for even (= 0 handicap) unranked games: " + config.colorsevenunranked};
+        }
+
+        if (!config.allowed_colors_handicap[notification.color] && (notification.handicap = 0) && !config.colorshandicapranked && !config.colorshandicapunranked) {
+            conn_log("opponent color " + notification.color + " is not allowed: " + notification.color + ", allowed colors for handicap games are :" + config.colorshandicap);
+            return { reject: true, msg: "color " + notification.color + " is not allowed, please choose one of these allowed colors for handicap (= 0 handicap) games: " + config.colorshandicap};
+        }
+
+        if (!config.allowed_colors_handicap_ranked[notification.color] && (notification.handicap = 0) && notification.ranked && config.colorshandicapranked) {
+            conn_log("opponent color " + notification.color + " is not allowed, allowed colors for handicap ranked games are :" + config.colorshandicapranked);
+            return { reject: true, msg: "color " + notification.color + " is not allowed, please choose one of these allowed colors for handicap (= 0 handicap) ranked games: " + config.colorshandicapranked};
+        }
+
+        if (!config.allowed_colors_handicap_unranked[notification.color] && (notification.handicap = 0) && !notification.ranked && config.colorshandicapunranked) {
+            conn_log("opponent color " + notification.color + " is not allowed, allowed colors for handicap unranked games are :" + config.colorshandicapunranked);
+            return { reject: true, msg: "color " + notification.color + " is not allowed, please choose one of these allowed colors for handicap (= 0 handicap) unranked games: " + config.colorshandicapunranked};
         }
 
         if (!config.allowed_speeds[t.speed] && !config.speedsranked && !config.speedsunranked) {

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -99,3 +99,20 @@ note that some gtp2ogs arguments come with a default general value : for the
 same reason, in that case, the default general value will not be taken into 
 account if you set a specific value for ranked and unranked games
 
+#### I :
+
+note 1 : for example, ```--colorshandicap black``` will reject all 
+games where opponent is not color black, which is the same as if 
+the bot is not color white : this is especially useful if you have 
+a very strong bot and if the game is a handicap game (with 1+ stones), 
+then your bot will be able to always give handicap stones to its 
+opponent even if the bot is lower ranked (ex: 5d bot giving 4 stones 
+to a 6d opponent)
+
+note 2 : in the example in the note 1 above, if challenge color 
+chosen by "automatic" or "random" color happen to be black, the 
+bot will still reject challenge because "automatic" (`-1`) and 
+"random" (`null`) are currently not supported by server to display 
+their accurate value ("black" or "white"), same as for automatic 
+handicap (`-1`) and automatic komi (`null`)
+

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -167,6 +167,31 @@ values are allowed and all other komi values are rejected see
 [notes C-](/docs/docs/NOTES.md#c-) and [notes D-](/docs/docs/NOTES.md#d-) 
 for details
 
+#### colors
+
+```--colorseven``` Opponent color(s) to accept for even 
+(= 0 handicap) games (default black,white,automatic,random)
+
+```--colorsevenranked``` Opponent color(s) to accept for even 
+(= 0 handicap) ranked games
+
+```--colorsevenunranked``` Opponent color(s) to accept for even 
+(= 0 handicap) unranked games
+
+```--colorshandicap``` Opponent color(s) to accept for handicap 
+games (default black,white,automatic,random)
+
+```--colorshandicapranked``` Opponent color(s) to accept for handicap 
+ranked games
+
+```--colorshandicapunranked``` Opponent color(s) to accept for handicap 
+unranked games
+
+note that `--colorshandicap` can be particularly useful if 
+you have a very strong bot and you want it to always give 
+handicap stone to any opponent, even if this opponent is 
+higher ranked, see [notes I-](/docs/docs/NOTES.md#i-) for details
+
 #### speeds
   ```--speeds``` Comma separated list of Game speed(s) to accept 
 (default blitz,live,correspondence)


### PR DESCRIPTION
@anoek @roy7 @Dorus @windo 

this PR is on top of #166 

as explained in #127 , sometimes in handicap games we end up 
giving handicap stones to weaker (but higher ranked) opponents, 
while our bot is superhuman (cant lose against humans even with 
handicap)
so in that example case, we would want to always give stones to 
bot opponents even if they are higher ranked, and reject game if 
that condition is not fullfilled

this PR addresses the issue expressed and proposes a generalization 
of challenge color rejects for 2 cases : 
- 1- even games
- 2- handicap games

for both cases, a default of allowing all colors is included, similar to how 
boardsizes, komis, speeds, and timecontrols families already work

to work, this PR needs server support to add `notification.color` 
to the challenge object
then we will be able to debug and test if the value of 
`notification.color` for "automatic" and "random" colors is 
`-1` or `null`, and slightly adjust this proposed code based 
on the result
in regards to that last point, this PR has a common point than with #165, 
where we want to know the automatic handicap stones true value 
(and not `-1` which is not a number of stones), except : 
- that here we should not have a bypass of min/max limits,
- and that we can start an initial support by just using an alias for "automatic" 
same as how notification.komi `null` is given the alias "automatic" in argv, 
so this is a mix of automatic handicap and automatic komi common issues, 
and then ideally we would like to have `notification.color.automatic` and 
`notification.color.random` too, so that for example is automatic or random 
color ends up chosing "black", we accept the game if `--colorshandicap black`

to sum up, we need server support for `notification.color` as a starter, 

big thanks :+1: 