### PR TITLE
Neat up messages/behavior when handling bot failures and exits

### DIFF
--- a/game.js
+++ b/game.js
@@ -81,7 +81,7 @@ class Game {
             // restart the bot by killing it here if another gamedata comes in. There normally should only be one
             // before we process any moves, and makeMove() is where a new Bot is created.
             let gamedataChanged = (JSON.stringify(this.state) !== JSON.stringify(gamedata));
-            if (this.bot) {
+            if (this.bot && gamedataChanged) {
                 this.log("Killing bot because of a gamedata change after bot was started");
                 if (config.DEBUG) {
                     this.log('Previously seen gamedata:', this.state);

--- a/game.js
+++ b/game.js
@@ -330,7 +330,7 @@ class Game {
 
     scheduleRetry() {
         if (config.DEBUG) {
-            this.log("We may need to move but were not able to. Re-connect to trigger action based on game state.");
+            this.log("Unable to react correctly - re-connect to trigger action based on game state.");
         }
         this.socket.emit('game/disconnect', this.auth({
             'game_id': this.game_id,

--- a/game.js
+++ b/game.js
@@ -80,9 +80,13 @@ class Game {
             // check if we're missing a move and send it to bot out of gamedata. For now as a safe fallback just
             // restart the bot by killing it here if another gamedata comes in. There normally should only be one
             // before we process any moves, and makeMove() is where a new Bot is created.
-            //
+            let gamedataChanged = (JSON.stringify(this.state) !== JSON.stringify(gamedata));
             if (this.bot) {
-                this.log("Killing bot because of gamedata packet after bot was started");
+                this.log("Killing bot because of a gamedata change after bot was started");
+                if (config.DEBUG) {
+                    this.log('Previously seen gamedata:', this.state);
+                    this.log('New gamedata:', gamedata);
+                }
                 this.ensureBotKilled();
 
                 if (this.processing) {


### PR DESCRIPTION
Meant to address #160

It stops the bot restarts on un-changed gamedata and tries to neaten up some of the messages (and related behavior) when handling bot failures and exits.