### PR TITLE
Fix bypass automatic handicap minmax limits using temporary --fakerank, and fix previously submitted functions, and add new functions as well

### DIFF
--- a/config.js
+++ b/config.js
@@ -577,11 +577,13 @@ exports.updateFromArgv = function() {
                     exports["allow_all_" + hashedArgNameStringConverted] = true;
                     // for example exports["allow_all_komis_ranked"] = true;
                 } else if (komi === "automatic") {
-                    exports[(prefixString + hashedArgNameStringConverted)[null]] = true;
-                    // for example exports["allowed_komis_ranked"[null]] = true;
+                    exports[prefixString + hashedArgNameStringConverted][null] = true;
+                    // for example exports["allowed_komis_ranked"][null] = true;
+                    // same as     exports.allowed_komis_ranked[null] = true;
                 } else {
-                    exports[(prefixString + hashedArgNameStringConverted)[komi]] = true;
-                    // for example exports["allowed_komis_ranked"[7.5]] = true;
+                    exports[prefixString + hashedArgNameStringConverted][komi] = true;
+                    // for example exports["allowed_komis_ranked"][7.5] = true;
+                    // same as     exports.allowed_komis_ranked[7.5] = true;
                 }
             }
 
@@ -598,21 +600,22 @@ exports.updateFromArgv = function() {
                     let hashedArgNameStringConvertedCustomHeights = jointArgStringToCustomHashedArgString(jointArgNameString, "heights");
                     // for example "boardsizesranked" => "boardsizewidths_ranked"
                     for (let width of argv[jointArgNameStringConvertedCustomWidths].split(',')) {
-                        exports[("allowed_custom_" + hashedArgNameStringConvertedCustomWidths)[width]] = true;
+                        exports["allowed_custom_" + hashedArgNameStringConvertedCustomWidths][width] = true;
                     }
                     for (let height of argv[jointArgNameStringConvertedCustomHeights].split(',')) {
-                        exports[("allowed_custom_" + hashedArgNameStringConvertedCustomHeights)[height]] = true;
+                        exports["allowed_custom_" + hashedArgNameStringConvertedCustomHeights][height] = true;
                     }
                 } else {
-                    exports[(prefixString + hashedArgNameStringConverted)[boardsize]] = true;
-                    // for example exports["allowed_boardsizes_ranked"[19]] = true;
+                    exports[prefixString + hashedArgNameStringConverted][boardsize] = true;
+                    // for example exports["allowed_boardsizes_ranked"][19] = true;
+                    // same as     exports.allowed_boardsizes_ranked[19] = true;
                 }
             }
 
         } else {
         // for non "boardsizes", non "komis" allowed families, switch back to default code :
             for (let e of argv[jointArgNameString].split(",")) {
-                exports[exportNameString[e]] = true;
+                exports[exportNameString][e] = true;
                 /* for example for (let e of argv["speedsranked"]) {
                                    exports["speeds_ranked"[e]] = true;
                                }

--- a/config.js
+++ b/config.js
@@ -242,6 +242,7 @@ exports.updateFromArgv = function() {
         .describe('noautohandicap', 'Do not allow handicap to be set to -automatic-')
         .describe('noautohandicapranked', 'Do not allow handicap to be set to -automatic- for ranked games')
         .describe('noautohandicapunranked', 'Do not allow handicap to be set to -automatic- for unranked games')
+        .describe('fakerank', 'Temporary manual bot ranking input by bot admin to fix autohandicap bypass issue, see /docs/OPTIONS-LIST.md for details')
         .describe('nopause', 'Do not allow games to be paused')
         .describe('nopauseranked', 'Do not allow ranked games to be paused')
         .describe('nopauseunranked', 'Do not allow unranked games to be paused')
@@ -423,6 +424,10 @@ exports.updateFromArgv = function() {
     if (argv.maxrankunranked) {
         parseMinmaxRankFromNameString("minrankunranked");
     }
+    if (argv.fakerank) {
+        parseMinmaxRankFromNameString("fakerank");
+    }
+    // TODO : remove fakerank when notification.bot.ranking is server implemented
 
     const familyNamesArray = generateHashedArrayFromFamilyNamesArray(["bans", "boardsizes", "komis", "speeds", "timecontrols"]);
 

--- a/config.js
+++ b/config.js
@@ -422,7 +422,7 @@ exports.updateFromArgv = function() {
         parseMinmaxRankFromNameString("maxrankranked");
     }
     if (argv.maxrankunranked) {
-        parseMinmaxRankFromNameString("minrankunranked");
+        parseMinmaxRankFromNameString("maxrankunranked");
     }
     if (argv.fakerank) {
         parseMinmaxRankFromNameString("fakerank");

--- a/config.js
+++ b/config.js
@@ -429,11 +429,129 @@ exports.updateFromArgv = function() {
     }
     // TODO : remove fakerank when notification.bot.ranking is server implemented
 
-    const familyNamesArray = generateHashedArrayFromFamilyNamesArray(["bans", "boardsizes", "komis", "speeds", "timecontrols"]);
+    if (argv.boardsizes) {
+        for (let boardsize of argv.boardsizes.split(',')) {
+            if (boardsize === "all") {
+                exports.allow_all_boardsizes = true;
+            } else if (boardsize === "custom") {
+                exports.allow_custom_boardsizes = true;
+                for (let boardsizewidth of argv.boardsizewidths.split(',')) {
+                    exports.allowed_custom_boardsizewidths[boardsizewidth] = true;
+                }
+                for (let boardsizeheight of argv.boardsizeheights.split(',')) {
+                    exports.allowed_custom_boardsizeheights[boardsizeheight] = true;
+                }
+            } else {
+                exports.allowed_boardsizes[boardsize] = true;
+            }
+        }
+    }
 
-    for (let familyName of familyNamesArray) {
-        if (argv[familyName]) {
-            allowedFamilyExport(familyName);
+    if (argv.boardsizesranked) {
+        for (let boardsizeranked of argv.boardsizesranked.split(',')) {
+            if (boardsizeranked === "all") {
+                exports.allow_all_boardsizes_ranked = true;
+            } else if (boardsizeranked === "custom") {
+                exports.allow_custom_boardsizes_ranked = true;
+                for (let boardsizewidthranked of argv.boardsizewidthsranked.split(',')) {
+                    exports.allowed_custom_boardsizewidths_ranked[boardsizewidthranked] = true;
+                }
+                for (let boardsizeheightranked of argv.boardsizeheightsranked.split(',')) {
+                    exports.allowed_custom_boardsizeheights_ranked[boardsizeheightranked] = true;
+                }
+            } else {
+                exports.allowed_boardsizes_ranked[boardsizeranked] = true;
+            }
+        }
+    }
+
+    if (argv.boardsizesunranked) {
+        for (let boardsizeunranked of argv.boardsizesunranked.split(',')) {
+            if (boardsizeunranked === "all") {
+                exports.allow_all_boardsizes_unranked = true;
+            } else if (boardsizeunranked === "custom") {
+                exports.allow_custom_boardsizes_unranked = true;
+                for (let boardsizewidthunranked of argv.boardsizeswidthunranked.split(',')) {
+                    exports.allowed_custom_boardsizewidths_unranked[boardsizewidthunranked] = true;
+                }
+                for (let boardsizeheightunranked of argv.boardsizeheightsunranked.split(',')) {
+                    exports.allowed_custom_boardsizeheights_unranked[boardsizeheightunranked] = true;
+                }
+            } else {
+                exports.allowed_boardsizes_unranked[boardsizeunranked] = true;
+            }
+        }
+    }
+
+    if (argv.komis) {
+        for (let komi of argv.komis.split(',')) {
+            if (komi === "all") {
+                exports.allow_all_komis = true;
+            } else if (komi === "automatic") {
+                exports.allowed_komis[null] = true;
+            } else {
+                exports.allowed_komis[komi] = true;
+            }
+        }
+    }
+
+    if (argv.komisranked) {
+        for (let komiranked of argv.komisranked.split(',')) {
+            if (komiranked === "all") {
+                exports.allow_all_komis_ranked = true;
+            } else if (komiranked === "automatic") {
+                exports.allowed_komis_ranked[null] = true;
+            } else {
+                exports.allowed_komis_ranked[komiranked] = true;
+            }
+        }
+    }
+
+    if (argv.komisunranked) {
+        for (let komiunranked of argv.komisunranked.split(',')) {
+            if (komiunranked === "all") {
+                exports.allow_all_komis_unranked = true;
+            } else if (komiunranked === "automatic") {
+                exports.allowed_komis_unranked[null] = true;
+            } else {
+                exports.allowed_komis_unranked[komiunranked] = true;
+            }
+        }
+    }
+
+    if (argv.speeds) {
+        for (let e of argv.speeds.split(',')) {
+            exports.allowed_speeds[e] = true;
+        }
+    }
+
+    if (argv.speedsranked) {
+        for (let e of argv.speedsranked.split(',')) {
+            exports.allowed_speeds_ranked[e] = true;
+        }
+    }
+
+    if (argv.speedsunranked) {
+        for (let e of argv.speedsunranked.split(',')) {
+            exports.allowed_speeds_unranked[e] = true;
+        }
+    }
+
+    if (argv.timecontrols) {
+        for (let e of argv.timecontrols.split(',')) {
+            exports.allowed_timecontrols[e] = true;
+        }
+    }
+
+    if (argv.timecontrolsranked) {
+        for (let e of argv.timecontrolsranked.split(',')) {
+            exports.allowed_timecontrols_ranked[e] = true;
+        }
+    }
+
+    if (argv.timecontrolsunranked) {
+        for (let e of argv.timecontrolunranked.split(',')) {
+            exports.allowed_timecontrols_unranked[e] = true;
         }
     }
 
@@ -472,155 +590,6 @@ exports.updateFromArgv = function() {
         } else {
             console.error(`Could not parse ${rankArgNameString} ${argv[rankArgNameString]}`);
             process.exit();
-        }
-    }
-
-    function jointArgStringToCustomJointArgString(jointArgString, widthsHeightsString) {
-        let jointArgStringToConvert = jointArgString.split("unranked")[0].split("ranked")[0].split("");
-        // for example "boardsizesranked" -> ["b", "o", "a", "r", "d", "s", "i", "z", "e", "s"]
-        jointArgStringToConvert.pop();
-        // for example ["s", "p", "e", "e", "d", "s"] -> ["b", "o", "a", "r", "d", "s", "i", "z", "e"]
-        jointArgStringToConvert = jointArgStringToConvert.join("");
-        // for example ["b", "o", "a", "r", "d", "s", "i", "z", "e"] -> "boardsize"
-        jointArgStringToConvert = jointArgStringToConvert + widthsHeightsString;
-        // for example "boardsize" -> "boardsizewidths"
-
-        // then, we define rankedUnranked and minMax depending on argNameString
-        let rankedUnranked = "";
-        // if hashedArgString does not include "ranked" or "unranked", we keep default value for rankedunranked
-        if (jointArgString.includes("ranked") && !jointArgString.includes("unranked")) {
-            rankedUnranked = "ranked";
-        } else if (jointArgString.includes("unranked")) {
-            rankedUnranked = "unranked";
-        }
-
-        // finally, we return joint Arg Name String
-        return (jointArgStringToConvert + rankedUnranked);
-        // for example return "boardsizewidthsranked";
-    }
-
-    function jointArgStringToCustomHashedArgString(jointArgString, widthsHeightsString) {
-        let jointArgStringToConvert = jointArgString.split("unranked")[0].split("ranked")[0].split("");
-        // for example "boardsizesranked" -> ["b", "o", "a", "r", "d", "s", "i", "z", "e", "s"]
-        jointArgStringToConvert.pop();
-        // for example ["s", "p", "e", "e", "d", "s"] -> ["b", "o", "a", "r", "d", "s", "i", "z", "e"]
-        jointArgStringToConvert = jointArgStringToConvert.join("");
-        // for example ["b", "o", "a", "r", "d", "s", "i", "z", "e"] -> "boardsize"
-        jointArgStringToConvert = jointArgStringToConvert + widthsHeightsString;
-        // for example "boardsize" -> "boardsizewidths"
-
-        // then, we define rankedUnranked and minMax depending on argNameString
-        let rankedUnranked = "";
-        // if hashedArgString does not include "ranked" or "unranked", we keep default value for rankedunranked
-        if (jointArgString.includes("ranked") && !jointArgString.includes("unranked")) {
-            rankedUnranked = "_ranked";
-        } else if (jointArgString.includes("unranked")) {
-            rankedUnranked = "_unranked";
-        }
-
-        // finally, we return hashed Arg Name String
-        return (jointArgStringToConvert + rankedUnranked);
-        // for example return "boardsizewidths_ranked";
-    }
-
-    function generateHashedArrayFromFamilyNamesArray(familyNamesArray) {
-        let bigFamilyArray = [];
-        for (let familyNameString of familyNamesArray) {
-            bigFamilyArray.push(familyNameString);
-            bigFamilyArray.push(familyNameString + "_ranked");
-            bigFamilyArray.push(familyNameString + "_unranked");
-        }
-        return bigFamilyArray;
-    }
-
-    function allowedFamilyExport(hashedArgNameString) {
-        // 1) first, we define the joint arg (example: "speedsranked")
-        let jointArgNameString = hashedArgNameString;
-        // we also add the exception of ranked/unranked hashed args
-        if (jointArgNameString.includes("ranked")) {
-            // "ranked" or "unranked"
-            jointArgNameString = jointArgNameString.split("_").join("");
-            // for example "speeds_ranked" => "speedsranked"
-        } // else we keep default jointArgNameString
-
-        // 2) then, we append the "allowed_" prefix,
-        //    and we also convert both the prefix and the hashed arg if needed 
-        //    (example "allowed_speeds_ranked", "banned_users_ranked")
-        let prefixString = "allowed_";
-        let hashedArgNameStringConverted = hashedArgNameString;
-        // then we add the exception of bans (different naming : 
-        // there is no "allowed_bans", + different formula) :
-        if (hashedArgNameStringConverted.includes("bans")) {
-            prefixString = "banned_users";
-            // final idea would be, at this current step :
-            // "allowed_bans_ranked" => "banned_users_bans_ranked"
-            if (hashedArgNameStringConverted.includes("ranked")) { // "ranked" or "unranked"
-                hashedArgNameStringConverted = "_" + hashedArgNameStringConverted.split("_")[1];
-                // for example "bans_ranked" => "_ranked"
-                // final idea would now be "banned_users" + "_ranked"
-            } else { 
-                hashedArgNameStringConverted = "";
-                // for example "bans" => ""
-                // final idea would now be "banned_users"
-            }
-        } // if not "bans" family, we keep default "allowed_" prefix String
-
-        let exportNameString = `${prefixString}${hashedArgNameStringConverted}`;
-        // for example exportNameString = "allowed_speeds_ranked";
-        // for example exportNameString = "banned_users_ranked";
-
-        // 3) then finally, the actual export
-        //    the export is different for "komis" and "boardsizes" families :
-        if (jointArgNameString.includes("komis")) {
-            for (let komi of argv[jointArgNameString].split(',')) {
-                if (komi === "all") {
-                    exports["allow_all_" + hashedArgNameStringConverted] = true;
-                    // for example exports["allow_all_komis_ranked"] = true;
-                } else if (komi === "automatic") {
-                    exports[prefixString + hashedArgNameStringConverted][null] = true;
-                    // for example exports["allowed_komis_ranked"][null] = true;
-                    // same as     exports.allowed_komis_ranked[null] = true;
-                } else {
-                    exports[prefixString + hashedArgNameStringConverted][komi] = true;
-                    // for example exports["allowed_komis_ranked"][7.5] = true;
-                    // same as     exports.allowed_komis_ranked[7.5] = true;
-                }
-            }
-
-        } else if (jointArgNameString.includes("boardsizes")) {
-            for (let boardsize of argv[jointArgNameString].split(',')) {
-                if (boardsize === "all") {
-                    exports["allow_all_" + hashedArgNameStringConverted] = true;
-                } else if (boardsize === "custom") {
-                    exports["allow_custom_" + hashedArgNameStringConverted] = true;
-                    let jointArgNameStringConvertedCustomWidths = jointArgStringToCustomJointArgString(jointArgNameString, "widths");
-                    let jointArgNameStringConvertedCustomHeights = jointArgStringToCustomJointArgString(jointArgNameString, "heights");
-                    // for example "boardsizesranked" => "boardsizewidthsranked"
-                    let hashedArgNameStringConvertedCustomWidths = jointArgStringToCustomHashedArgString(jointArgNameString, "widths");
-                    let hashedArgNameStringConvertedCustomHeights = jointArgStringToCustomHashedArgString(jointArgNameString, "heights");
-                    // for example "boardsizesranked" => "boardsizewidths_ranked"
-                    for (let width of argv[jointArgNameStringConvertedCustomWidths].split(',')) {
-                        exports["allowed_custom_" + hashedArgNameStringConvertedCustomWidths][width] = true;
-                    }
-                    for (let height of argv[jointArgNameStringConvertedCustomHeights].split(',')) {
-                        exports["allowed_custom_" + hashedArgNameStringConvertedCustomHeights][height] = true;
-                    }
-                } else {
-                    exports[prefixString + hashedArgNameStringConverted][boardsize] = true;
-                    // for example exports["allowed_boardsizes_ranked"][19] = true;
-                    // same as     exports.allowed_boardsizes_ranked[19] = true;
-                }
-            }
-
-        } else {
-        // for non "boardsizes", non "komis" allowed families, switch back to default code :
-            for (let e of argv[jointArgNameString].split(",")) {
-                exports[exportNameString][e] = true;
-                /* for example for (let e of argv["speedsranked"]) {
-                                   exports["speeds_ranked"[e]] = true;
-                               }
-            */
-            }
         }
     }
 

--- a/config.js
+++ b/config.js
@@ -405,24 +405,6 @@ exports.updateFromArgv = function() {
         return false;
     }
 
-    if (argv.bans) {
-        for (let e of argv.bans.split(',')) {
-            exports.banned_users[e] = true;
-        }
-    }
-
-    if (argv.bansranked) {
-        for (let e of argv.bansranked.split(',')) {
-            exports.banned_users_ranked[e] = true;
-        }
-    }
-
-    if (argv.bansunranked) {
-        for (let e of argv.bansunranked.split(',')) {
-            exports.banned_users_unranked[e] = true;
-        }
-    }
-
     if (argv.minrank && !argv.minrankranked && !argv.minrankunranked) {
         parseMinmaxRankFromNameString("minrank");
     }
@@ -442,129 +424,11 @@ exports.updateFromArgv = function() {
         parseMinmaxRankFromNameString("minrankunranked");
     }
 
-    if (argv.boardsizes) {
-        for (let boardsize of argv.boardsizes.split(',')) {
-            if (boardsize === "all") {
-                exports.allow_all_boardsizes = true;
-            } else if (boardsize === "custom") {
-                exports.allow_custom_boardsizes = true;
-                for (let boardsizewidth of argv.boardsizewidths.split(',')) {
-                    exports.allowed_custom_boardsizewidths[boardsizewidth] = true;
-                }
-                for (let boardsizeheight of argv.boardsizeheights.split(',')) {
-                    exports.allowed_custom_boardsizeheights[boardsizeheight] = true;
-                }
-            } else {
-                exports.allowed_boardsizes[boardsize] = true;
-            }
-        }
-    }
+    const familyNamesArray = generateHashedArrayFromFamilyNamesArray(["bans", "boardsizes", "komis", "speeds", "timecontrols"]);
 
-    if (argv.boardsizesranked) {
-        for (let boardsizeranked of argv.boardsizesranked.split(',')) {
-            if (boardsizeranked === "all") {
-                exports.allow_all_boardsizes_ranked = true;
-            } else if (boardsizeranked === "custom") {
-                exports.allow_custom_boardsizes_ranked = true;
-                for (let boardsizewidthranked of argv.boardsizewidthsranked.split(',')) {
-                    exports.allowed_custom_boardsizewidths_ranked[boardsizewidthranked] = true;
-                }
-                for (let boardsizeheightranked of argv.boardsizeheightsranked.split(',')) {
-                    exports.allowed_custom_boardsizeheights_ranked[boardsizeheightranked] = true;
-                }
-            } else {
-                exports.allowed_boardsizes_ranked[boardsizeranked] = true;
-            }
-        }
-    }
-
-    if (argv.boardsizesunranked) {
-        for (let boardsizeunranked of argv.boardsizesunranked.split(',')) {
-            if (boardsizeunranked === "all") {
-                exports.allow_all_boardsizes_unranked = true;
-            } else if (boardsizeunranked === "custom") {
-                exports.allow_custom_boardsizes_unranked = true;
-                for (let boardsizewidthunranked of argv.boardsizeswidthunranked.split(',')) {
-                    exports.allowed_custom_boardsizewidths_unranked[boardsizewidthunranked] = true;
-                }
-                for (let boardsizeheightunranked of argv.boardsizeheightsunranked.split(',')) {
-                    exports.allowed_custom_boardsizeheights_unranked[boardsizeheightunranked] = true;
-                }
-            } else {
-                exports.allowed_boardsizes_unranked[boardsizeunranked] = true;
-            }
-        }
-    }
-
-    if (argv.komis) {
-        for (let komi of argv.komis.split(',')) {
-            if (komi === "all") {
-                exports.allow_all_komis = true;
-            } else if (komi === "automatic") {
-                exports.allowed_komis[null] = true;
-            } else {
-                exports.allowed_komis[komi] = true;
-            }
-        }
-    }
-
-    if (argv.komisranked) {
-        for (let komiranked of argv.komisranked.split(',')) {
-            if (komiranked === "all") {
-                exports.allow_all_komis_ranked = true;
-            } else if (komiranked === "automatic") {
-                exports.allowed_komis_ranked[null] = true;
-            } else {
-                exports.allowed_komis_ranked[komiranked] = true;
-            }
-        }
-    }
-
-    if (argv.komisunranked) {
-        for (let komiunranked of argv.komisunranked.split(',')) {
-            if (komiunranked === "all") {
-                exports.allow_all_komis_unranked = true;
-            } else if (komiunranked === "automatic") {
-                exports.allowed_komis_unranked[null] = true;
-            } else {
-                exports.allowed_komis_unranked[komiunranked] = true;
-            }
-        }
-    }
-
-    if (argv.speeds) {
-        for (let e of argv.speeds.split(',')) {
-            exports.allowed_speeds[e] = true;
-        }
-    }
-
-    if (argv.speedsranked) {
-        for (let e of argv.speedsranked.split(',')) {
-            exports.allowed_speeds_ranked[e] = true;
-        }
-    }
-
-    if (argv.speedsunranked) {
-        for (let e of argv.speedsunranked.split(',')) {
-            exports.allowed_speeds_unranked[e] = true;
-        }
-    }
-
-    if (argv.timecontrols) {
-        for (let e of argv.timecontrols.split(',')) {
-            exports.allowed_timecontrols[e] = true;
-        }
-    }
-
-    if (argv.timecontrolsranked) {
-        for (let e of argv.timecontrolsranked.split(',')) {
-            exports.allowed_timecontrols_ranked[e] = true;
-        }
-    }
-
-    if (argv.timecontrolsunranked) {
-        for (let e of argv.timecontrolunranked.split(',')) {
-            exports.allowed_timecontrols_unranked[e] = true;
+    for (let familyName of familyNamesArray) {
+        if (argv[familyName]) {
+            allowedFamilyExport(familyName);
         }
     }
 
@@ -603,6 +467,152 @@ exports.updateFromArgv = function() {
         } else {
             console.error(`Could not parse ${rankArgNameString} ${argv[rankArgNameString]}`);
             process.exit();
+        }
+    }
+
+    function jointArgStringToCustomJointArgString(jointArgString, widthsHeightsString) {
+        let jointArgStringToConvert = jointArgString.split("unranked")[0].split("ranked")[0].split("");
+        // for example "boardsizesranked" -> ["b", "o", "a", "r", "d", "s", "i", "z", "e", "s"]
+        jointArgStringToConvert.pop();
+        // for example ["s", "p", "e", "e", "d", "s"] -> ["b", "o", "a", "r", "d", "s", "i", "z", "e"]
+        jointArgStringToConvert = jointArgStringToConvert.join("");
+        // for example ["b", "o", "a", "r", "d", "s", "i", "z", "e"] -> "boardsize"
+        jointArgStringToConvert = jointArgStringToConvert + widthsHeightsString;
+        // for example "boardsize" -> "boardsizewidths"
+
+        // then, we define rankedUnranked and minMax depending on argNameString
+        let rankedUnranked = "";
+        // if hashedArgString does not include "ranked" or "unranked", we keep default value for rankedunranked
+        if (jointArgString.includes("ranked") && !jointArgString.includes("unranked")) {
+            rankedUnranked = "ranked";
+        } else if (jointArgString.includes("unranked")) {
+            rankedUnranked = "unranked";
+        }
+
+        // finally, we return joint Arg Name String
+        return (jointArgStringToConvert + rankedUnranked);
+        // for example return "boardsizewidthsranked";
+    }
+
+    function jointArgStringToCustomHashedArgString(jointArgString, widthsHeightsString) {
+        let jointArgStringToConvert = jointArgString.split("unranked")[0].split("ranked")[0].split("");
+        // for example "boardsizesranked" -> ["b", "o", "a", "r", "d", "s", "i", "z", "e", "s"]
+        jointArgStringToConvert.pop();
+        // for example ["s", "p", "e", "e", "d", "s"] -> ["b", "o", "a", "r", "d", "s", "i", "z", "e"]
+        jointArgStringToConvert = jointArgStringToConvert.join("");
+        // for example ["b", "o", "a", "r", "d", "s", "i", "z", "e"] -> "boardsize"
+        jointArgStringToConvert = jointArgStringToConvert + widthsHeightsString;
+        // for example "boardsize" -> "boardsizewidths"
+
+        // then, we define rankedUnranked and minMax depending on argNameString
+        let rankedUnranked = "";
+        // if hashedArgString does not include "ranked" or "unranked", we keep default value for rankedunranked
+        if (jointArgString.includes("ranked") && !jointArgString.includes("unranked")) {
+            rankedUnranked = "_ranked";
+        } else if (jointArgString.includes("unranked")) {
+            rankedUnranked = "_unranked";
+        }
+
+        // finally, we return hashed Arg Name String
+        return (jointArgStringToConvert + rankedUnranked);
+        // for example return "boardsizewidths_ranked";
+    }
+
+    function generateHashedArrayFromFamilyNamesArray(familyNamesArray) {
+        let bigFamilyArray = [];
+        for (let familyNameString of familyNamesArray) {
+            bigFamilyArray.push(familyNameString);
+            bigFamilyArray.push(familyNameString + "_ranked");
+            bigFamilyArray.push(familyNameString + "_unranked");
+        }
+        return bigFamilyArray;
+    }
+
+    function allowedFamilyExport(hashedArgNameString) {
+        // 1) first, we define the joint arg (example: "speedsranked")
+        let jointArgNameString = hashedArgNameString;
+        // we also add the exception of ranked/unranked hashed args
+        if (jointArgNameString.includes("ranked")) {
+            // "ranked" or "unranked"
+            jointArgNameString = jointArgNameString.split("_").join("");
+            // for example "speeds_ranked" => "speedsranked"
+        } // else we keep default jointArgNameString
+
+        // 2) then, we append the "allowed_" prefix,
+        //    and we also convert both the prefix and the hashed arg if needed 
+        //    (example "allowed_speeds_ranked", "banned_users_ranked")
+        let prefixString = "allowed_";
+        let hashedArgNameStringConverted = hashedArgNameString;
+        // then we add the exception of bans (different naming : 
+        // there is no "allowed_bans", + different formula) :
+        if (hashedArgNameStringConverted.includes("bans")) {
+            prefixString = "banned_users";
+            // final idea would be, at this current step :
+            // "allowed_bans_ranked" => "banned_users_bans_ranked"
+            if (hashedArgNameStringConverted.includes("ranked")) { // "ranked" or "unranked"
+                hashedArgNameStringConverted = "_" + hashedArgNameStringConverted.split("_")[1];
+                // for example "bans_ranked" => "_ranked"
+                // final idea would now be "banned_users" + "_ranked"
+            } else { 
+                hashedArgNameStringConverted = "";
+                // for example "bans" => ""
+                // final idea would now be "banned_users"
+            }
+        } // if not "bans" family, we keep default "allowed_" prefix String
+
+        let exportNameString = `${prefixString}${hashedArgNameStringConverted}`;
+        // for example exportNameString = "allowed_speeds_ranked";
+        // for example exportNameString = "banned_users_ranked";
+
+        // 3) then finally, the actual export
+        //    the export is different for "komis" and "boardsizes" families :
+        if (jointArgNameString.includes("komis")) {
+            for (let komi of argv[jointArgNameString].split(',')) {
+                if (komi === "all") {
+                    exports["allow_all_" + hashedArgNameStringConverted] = true;
+                    // for example exports["allow_all_komis_ranked"] = true;
+                } else if (komi === "automatic") {
+                    exports[(prefixString + hashedArgNameStringConverted)[null]] = true;
+                    // for example exports["allowed_komis_ranked"[null]] = true;
+                } else {
+                    exports[(prefixString + hashedArgNameStringConverted)[komi]] = true;
+                    // for example exports["allowed_komis_ranked"[7.5]] = true;
+                }
+            }
+
+        } else if (jointArgNameString.includes("boardsizes")) {
+            for (let boardsize of argv[jointArgNameString].split(',')) {
+                if (boardsize === "all") {
+                    exports["allow_all_" + hashedArgNameStringConverted] = true;
+                } else if (boardsize === "custom") {
+                    exports["allow_custom_" + hashedArgNameStringConverted] = true;
+                    let jointArgNameStringConvertedCustomWidths = jointArgStringToCustomJointArgString(jointArgNameString, "widths");
+                    let jointArgNameStringConvertedCustomHeights = jointArgStringToCustomJointArgString(jointArgNameString, "heights");
+                    // for example "boardsizesranked" => "boardsizewidthsranked"
+                    let hashedArgNameStringConvertedCustomWidths = jointArgStringToCustomHashedArgString(jointArgNameString, "widths");
+                    let hashedArgNameStringConvertedCustomHeights = jointArgStringToCustomHashedArgString(jointArgNameString, "heights");
+                    // for example "boardsizesranked" => "boardsizewidths_ranked"
+                    for (let width of argv[jointArgNameStringConvertedCustomWidths].split(',')) {
+                        exports[("allowed_custom_" + hashedArgNameStringConvertedCustomWidths)[width]] = true;
+                    }
+                    for (let height of argv[jointArgNameStringConvertedCustomHeights].split(',')) {
+                        exports[("allowed_custom_" + hashedArgNameStringConvertedCustomHeights)[height]] = true;
+                    }
+                } else {
+                    exports[(prefixString + hashedArgNameStringConverted)[boardsize]] = true;
+                    // for example exports["allowed_boardsizes_ranked"[19]] = true;
+                }
+            }
+
+        } else {
+        // for non "boardsizes", non "komis" allowed families, switch back to default code :
+            for (let e of argv[jointArgNameString].split(",")) {
+                exports[exportNameString[e]] = true;
+                /* for example for (let e of argv["speedsranked"]) {
+                                   exports["speeds_ranked"[e]] = true;
+                               }
+            */
+            }
         }
     }
 

--- a/connection.js
+++ b/connection.js
@@ -1706,12 +1706,14 @@ class Connection {
             let argFamilySingularString = pluralFamilyStringToSingularString(argNameString);
             // for example "speedsranked" -> "speed"
 
-            // then, we process the inputs to human readable, 
-            let argConverted = argNameString;
+            // then, we process the inputs to human readable, and convert them if needed
+            let argValueString = config[argNameString];
+            // for example config["boardsizesranked"];
             let notificationUnitConverted = notificationUnit;
             // if argFamilySingularString family is "boardsize" type :
             if (argFamilySingularString.includes("boardsize")) {
-                argConverted = boardsizeSquareToDisplayString(config[argNameString]);
+                argValueString = boardsizeSquareToDisplayString(config[argNameString]);
+                // for example boardsizeSquareToDisplayString("9,13,19"]) : "9x9, 13x13, 19x19"
                 notificationUnitConverted = boardsizeSquareToDisplayString(notificationUnit);
             }
             // if argFamilySingularString family is "komi" type :
@@ -1723,9 +1725,9 @@ class Connection {
             // else we dont dont convert : we dont change anything
 
             // then finally, the actual reject :
-            conn_log(`${user.username} wanted ${argFamilySingularString} ${rankedUnranked}-${notificationUnitConverted}-, not in -${config[argConverted]}- `);
+            conn_log(`${user.username} wanted ${argFamilySingularString} ${rankedUnranked}-${notificationUnitConverted}-, not in -${argValueString}- `);
             // for example : "user wanted speed for ranked games -blitz-, not in -live,correspondence-
-            return { reject: true, msg: `${argFamilySingularString} -${notificationUnitConverted}- is not allowed on this bot ${rankedUnranked}, please choose one of these allowed ${argFamilySingularString}s ${rankedUnranked} : -${config[argConverted]}-` };
+            return { reject: true, msg: `${argFamilySingularString} -${notificationUnitConverted}- is not allowed on this bot ${rankedUnranked}, please choose one of these allowed ${argFamilySingularString}s ${rankedUnranked} : -${argValueString}-` };
             /* for example : "speed -blitz- is not allowed on this bot for ranked games, please
                              choose one of these allowed speeds for ranked games : 
                              -live,correspondence-"

--- a/connection.js
+++ b/connection.js
@@ -1866,6 +1866,7 @@ function timespanToDisplayString(timespan) { /* {{{ */
 
 function boardsizeSquareToDisplayString(boardsizeSquare) { /* {{{ */
     return boardsizeSquare
+    .toString()
     .split(',')
     .map(e => e.trim())
     .map(e => `${e}x${e}`)

--- a/connection.js
+++ b/connection.js
@@ -428,18 +428,17 @@ class Connection {
         // all at the same time if bot admin wants
 
         /******** begining of BOARDSIZES *********/
+
         // for square board sizes only //
         /* if not square*/
         if (notification.width !== notification.height && !config.allow_all_boardsizes && !config.allow_custom_boardsizes && !config.boardsizesranked && !config.boardsizesunranked) {
             let result = boardsizeNotificationIsNotSquareReject("boardsizes");
             if (result) return (result);
         }
-
         if (notification.width !== notification.height && !config.allow_all_boardsizes_ranked && !config.allow_custom_boardsizes_ranked && notification.ranked) {
             let result = boardsizeNotificationIsNotSquareReject("boardsizesranked");
             if (result) return (result);
         }
-
         if (notification.width !== notification.height && !config.allow_all_boardsizes_unranked && !config.allow_custom_boardsizes_unranked && !notification.ranked) {
             let result = boardsizeNotificationIsNotSquareReject("boardsizesunranked");
             if (result) return (result);
@@ -450,12 +449,10 @@ class Connection {
             let result = genericAllowedFamiliesReject("boardsizes", notification.width);
             if (result) return (result);
         }
-
         if (!config.allowed_boardsizes_ranked[notification.width] && !config.allow_all_boardsizes_ranked && !config.allow_custom_boardsizes_ranked && notification.ranked && config.boardsizesranked) {
             let result = genericAllowedFamiliesReject("boardsizesranked", notification.width);
             if (result) return (result);
         }
-
         if (!config.allowed_boardsizes_unranked[notification.width] && !config.allow_all_boardsizes_unranked && !config.allow_custom_boardsizes_unranked && !notification.ranked && config.boardsizesunranked) {
             let result = genericAllowedFamiliesReject("boardsizesunranked", notification.width);
             if (result) return (result);
@@ -467,12 +464,10 @@ class Connection {
             let result = customBoardsizeWidthsHeightsReject("boardsizewidths");
             if (result) return (result);
         }
-
         if (!config.allow_all_boardsizes_ranked && config.allow_custom_boardsizes_ranked && !config.allowed_custom_boardsizewidths_ranked[notification.width] && notification.ranked && config.boardsizewidthsranked) {
             let result = customBoardsizeWidthsHeightsReject("boardsizewidthsranked");
             if (result) return (result);
         }
-
         if (!config.allow_all_boardsizes_unranked && config.allow_custom_boardsizes_unranked && !config.allowed_custom_boardsizewidths_unranked[notification.width] && !notification.ranked && config.boardsizewidthsunranked) {
             let result = customBoardsizeWidthsHeightsReject("boardsizewidthsunranked");
             if (result) return (result);
@@ -483,12 +478,10 @@ class Connection {
             let result = customBoardsizeWidthsHeightsReject("boardsizeheights");
             if (result) return (result);
         }
-
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizeheights[notification.height] && notification.ranked && config.boardsizeheightsranked) {
             let result = customBoardsizeWidthsHeightsReject("boardsizeheightsranked");
             if (result) return (result);
         }
-
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizeheights[notification.height] && !notification.ranked && config.boardsizeheightsunranked) {
             let result = customBoardsizeWidthsHeightsReject("boardsizeheightsunranked");
             if (result) return (result);
@@ -496,18 +489,16 @@ class Connection {
         /******** end of BOARDSIZES *********/
 
         if (notification.handicap === -1 && config.noautohandicap) {
-            conn_log("no autohandicap");
-            return { reject: true, msg: "For easier bot management, automatic handicap is disabled on this bot, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones" };
+            let result = noAutohandicapReject("noautohandicap");
+            if (result) return (result);
 	}
-
         if (notification.handicap === -1 && config.noautohandicapranked && notification.ranked) {
-            conn_log("no autohandicap for ranked games");
-            return { reject: true, msg: "For easier bot management, automatic handicap is disabled for ranked games on this bot, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones" };
+            let result = noAutohandicapReject("noautohandicapranked");
+            if (result) return (result);
 	}
-
         if (notification.handicap === -1 && config.noautohandicapunranked && !notification.ranked) {
-            conn_log("no autohandicap for unranked games");
-            return { reject: true, msg: "For easier bot management, automatic handicap is disabled for unranked games on this bot, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones" };
+            let result = noAutohandicapReject("noautohandicapunranked");
+            if (result) return (result);
 	}
 
         /***** automatic handicap min/max handicap limits detection ******/
@@ -1741,6 +1732,22 @@ class Connection {
             return { reject: true, msg: `Your automatic handicap ${rankedUnranked} was automatically set to ${rankDifference} stones based on rank difference between you and this bot,\nBut ${minMax} handicap ${rankedUnranked} is ${config[argNameString]} stones \nPlease ${increaseDecrease} the number of handicap stones ${rankedUnranked} in -custom handicap-` };
         }
 
+        function noAutohandicapReject(argNameString) {
+            // first, we define rankedUnranked, depending on argNameString
+
+            let rankedUnranked = "";
+            // if argNameString does not include "ranked" or "unranked", we keep default value for rankedunranked
+            if (argNameString.includes("ranked") && !argNameString.includes("unranked")) {
+                rankedUnranked = "for ranked games";
+            } else if (argNameString.includes("unranked")) {
+                rankedUnranked = "for unranked games";
+            }
+
+            // then finally, the actual reject :
+            conn_log(`no autohandicap ${rankedUnranked}`);
+            return { reject: true, msg: `For easier bot management, -automatic- handicap is disabled on this bot ${rankedUnranked}, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones` };
+        }
+
         function genericAllowedFamiliesReject(argNameString, notificationUnit) {
             // first, we define rankedUnranked, argFamilySingularString, depending on argNameString
 
@@ -1805,9 +1812,9 @@ class Connection {
             let rankedUnranked = "";
             // if argNameString does not include "ranked" or "unranked", we keep default value for rankedunranked
             if (argNameString.includes("ranked") && !argNameString.includes("unranked")) {
-                rankedUnranked = "for ranked games ";
+                rankedUnranked = "for ranked games";
             } else if (argNameString.includes("unranked")) {
-                rankedUnranked = "for unranked games ";
+                rankedUnranked = "for unranked games";
             }
 
             let widthHeight = "";
@@ -1824,7 +1831,7 @@ class Connection {
             // then finally, the actual reject :
             conn_log(`${user.username} wanted boardsize ${widthHeight} ${rankedUnranked}-${notificationUnit}-, not in -${config[argNameString]}- `);
             // for example : "user wanted boardsize width for ranked games -15-, not in -17,19,25-
-            return { reject: true, msg: `In your selected board size ${notification.width} x ${notification.height} (width x height), boardsize ${widthHeight.toUpperCase()} (${notificationUnit}) is not allowed ${rankedUnranked} on this bot, please choose one of these allowed CUSTOM boardsize ${widthHeight.toUpperCase()}S values for ${rankedUnranked} : ${config[argNameString]}` };
+            return { reject: true, msg: `In your selected board size ${notification.width} x ${notification.height} (width x height), boardsize ${widthHeight.toUpperCase()} (${notificationUnit}) is not allowed ${rankedUnranked} on this bot, please choose one of these allowed CUSTOM boardsize ${widthHeight.toUpperCase()}S values ${rankedUnranked} : ${config[argNameString]}` };
             /* for example : In your selected board size 15 x 2 (width x height), boardsize WIDTH (15) is not allowed for ranked games on this bot, please choose one of these allowed CUSTOM boardsize WIDTHS values for ranked games : 17,19,25
             */
         }

--- a/connection.js
+++ b/connection.js
@@ -1740,7 +1740,7 @@ class Connection {
 
             // then finally, the actual reject :
             conn_log(`boardsize ${notification.width} x ${notification.height} is not square, not allowed`);
-            return { reject: true, msg: `Your selected board size ${notification.width} x ${notification.height} is not square, not allowed ${rankedUnranked} on this bot, please choose a SQUARE board size (same width and height), for example ${boardsizeSquareToDisplayString(config[argNameString])}` };
+            return { reject: true, msg: `Your selected board size ${notification.width} x ${notification.height} is not square, not allowed ${rankedUnranked} on this bot, please choose a SQUARE board size (same width and height), for example try 9x9 or 19x19}` };
         }
 
         function customBoardsizeWidthsHeightsReject(argNameString) {

--- a/connection.js
+++ b/connection.js
@@ -464,34 +464,34 @@ class Connection {
         // for custom board sizes, including square board sizes if width === height as well //
         /* if custom, check width */
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizewidths[notification.width] && !config.boardsizewidthsranked && !config.boardsizewidthsunranked) {
-            conn_log("custom board width " + notification.width + " is not an allowed custom board width");
-            return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board WIDTH (" + notification.width + ") is not allowed, please choose one of these allowed CUSTOM board WIDTH values : " + config.boardsizewidths };
+            let result = customBoardsizeWidthsHeightsReject("boardsizewidths");
+            if (result) return (result);
         }
 
         if (!config.allow_all_boardsizes_ranked && config.allow_custom_boardsizes_ranked && !config.allowed_custom_boardsizewidths_ranked[notification.width] && notification.ranked && config.boardsizewidthsranked) {
-            conn_log("custom board width " + notification.width + " is not an allowed custom board width for ranked games");
-            return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board WIDTH (" + notification.width + ") is not allowed for ranked games, please choose one of these allowed CUSTOM board WIDTH values for ranked games : " + config.boardsizewidthsranked };
+            let result = customBoardsizeWidthsHeightsReject("boardsizewidthsranked");
+            if (result) return (result);
         }
 
         if (!config.allow_all_boardsizes_unranked && config.allow_custom_boardsizes_unranked && !config.allowed_custom_boardsizewidths_unranked[notification.width] && !notification.ranked && config.boardsizewidthsunranked) {
-            conn_log("custom board width " + notification.width + " is not an allowed custom board width for unranked games");
-            return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board WIDTH (" + notification.width + ") is not allowed for unranked games, please choose one of these allowed CUSTOM board WIDTH values for unranked games : " + config.boardsizewidthsunranked };
+            let result = customBoardsizeWidthsHeightsReject("boardsizewidthsunranked");
+            if (result) return (result);
         }
 
         /* if custom, check height */
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizeheights[notification.height] && !config.boardsizeheightsranked && !config.boardsizeheightsunranked) {
-            conn_log("custom board height " + notification.height + " is not an allowed custom board height");
-            return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board HEIGHT (" + notification.height + ") is not allowed, please choose one of these allowed CUSTOM board HEIGHT values : " + config.boardsizeheights };
+            let result = customBoardsizeWidthsHeightsReject("boardsizeheights");
+            if (result) return (result);
         }
 
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizeheights[notification.height] && notification.ranked && config.boardsizeheightsranked) {
-            conn_log("custom board height " + notification.height + " is not an allowed custom board height for ranked games ");
-            return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board HEIGHT (" + notification.height + ") is not allowed for ranked games, please choose one of these allowed CUSTOM board HEIGHT values for ranked games: " + config.boardsizeheights };
+            let result = customBoardsizeWidthsHeightsReject("boardsizeheightsranked");
+            if (result) return (result);
         }
 
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizeheights[notification.height] && !notification.ranked && config.boardsizeheightsunranked) {
-            conn_log("custom board height " + notification.height + " is not an allowed custom board height for unranked games ");
-            return { reject: true, msg: "In your selected board size " + notification.width + "x" + notification.height + " (width x height), board HEIGHT (" + notification.height + ") is not allowed for unranked games, please choose one of these allowed CUSTOM board HEIGHT values for unranked games: " + config.boardsizeheights };
+            let result = customBoardsizeWidthsHeightsReject("boardsizeheightsunranked");
+            if (result) return (result);
         }
         /******** end of BOARDSIZES *********/
 
@@ -1780,6 +1780,36 @@ class Connection {
             /* for example : "speed -blitz- is not allowed on this bot for ranked games, please
                              choose one of these allowed speeds for ranked games : 
                              -live,correspondence-"
+            */
+        }
+
+        function customBoardsizeWidthsHeightsReject(argNameString) {
+            // first, we define rankedUnranked, widthHeight, depending on argNameString
+
+            let rankedUnranked = "";
+            // if argNameString does not include "ranked" or "unranked", we keep default value for rankedunranked
+            if (argNameString.includes("ranked") && !argNameString.includes("unranked")) {
+                rankedUnranked = "for ranked games ";
+            } else if (argNameString.includes("unranked")) {
+                rankedUnranked = "for unranked games ";
+            }
+
+            let widthHeight = "";
+            let notificationUnit = "";
+            if (argNameString.includes("width")) {
+                widthHeight = "width";
+                notificationUnit = notification[widthHeight];
+            }
+            if (argNameString.includes("height")) {
+                widthHeight = "height";
+                notificationUnit = notification[widthHeight];
+            }
+
+            // then finally, the actual reject :
+            conn_log(`${user.username} wanted boardsize ${widthHeight} ${rankedUnranked}-${notificationUnit}-, not in -${config[argNameString]}- `);
+            // for example : "user wanted boardsize width for ranked games -15-, not in -17,19,25-
+            return { reject: true, msg: `In your selected board size ${notification.width} x ${notification.height} (width x height), boardsize ${widthHeight.toUpperCase()} (${notificationUnit}) is not allowed for ${rankedUnranked} on this bot, please choose one of these allowed CUSTOM boardsize ${widthHeight.toUpperCase()}S values for ${rankedUnranked} : ${config[argNameString]}` };
+            /* for example : In your selected board size 15 x 2 (width x height), boardsize WIDTH (15) is not allowed for ranked games on this bot, please choose one of these allowed CUSTOM boardsize WIDTHS values for ranked games : 17,19,25
             */
         }
 

--- a/connection.js
+++ b/connection.js
@@ -431,18 +431,18 @@ class Connection {
         // for square board sizes only //
         /* if not square*/
         if (notification.width !== notification.height && !config.allow_all_boardsizes && !config.allow_custom_boardsizes && !config.boardsizesranked && !config.boardsizesunranked) {
-            conn_log("board was not square, not allowed");
-            return { reject: true, msg: "Your selected board size " + notification.width + "x" + notification.height + " (width x height), is not square, not allowed, please choose a square board size (same width and height, for example 9x9 or 19x19). " };
+            let result = boardsizeNotificationIsNotSquareReject("boardsizes");
+            if (result) return (result);
         }
 
         if (notification.width !== notification.height && !config.allow_all_boardsizes_ranked && !config.allow_custom_boardsizes_ranked && notification.ranked) {
-            conn_log("board was not square, not allowed for ranked games");
-            return { reject: true, msg: "Your selected board size " + notification.width + "x" + notification.height + " (width x height), is not square, not allowed for ranked games, please choose a square board size (same width and height, for example 9x9 or 19x19). " };
+            let result = boardsizeNotificationIsNotSquareReject("boardsizesranked");
+            if (result) return (result);
         }
 
         if (notification.width !== notification.height && !config.allow_all_boardsizes_unranked && !config.allow_custom_boardsizes_unranked && !notification.ranked) {
-            conn_log("board was not square, not allowed for unranked games");
-            return { reject: true, msg: "Your selected board size " + notification.width + "x" + notification.height + " (width x height), is not square, not allowed for unranked games, please choose a square board size (same width and height, for example 9x9 or 19x19). " };
+            let result = boardsizeNotificationIsNotSquareReject("boardsizesunranked");
+            if (result) return (result);
         }
 
         /* if square, check if square board size is allowed*/
@@ -1783,6 +1783,22 @@ class Connection {
             */
         }
 
+        function boardsizeNotificationIsNotSquareReject(argNameString) {
+            // first, we define rankedUnranked, depending on argNameString
+
+            let rankedUnranked = "";
+            // if argNameString does not include "ranked" or "unranked", we keep default value for rankedunranked
+            if (argNameString.includes("ranked") && !argNameString.includes("unranked")) {
+                rankedUnranked = "for ranked games";
+            } else if (argNameString.includes("unranked")) {
+                rankedUnranked = "for unranked games";
+            }
+
+            // then finally, the actual reject :
+            conn_log(`boardsize ${notification.width} x ${notification.height} is not square, not allowed`);
+            return { reject: true, msg: `Your selected board size ${notification.width} x ${notification.height} is not square, not allowed ${rankedUnranked} on this bot, please choose a SQUARE board size (same width and height), for example ${boardsizeSquareToDisplayString(config[argNameString])}` };
+        }
+
         function customBoardsizeWidthsHeightsReject(argNameString) {
             // first, we define rankedUnranked, widthHeight, depending on argNameString
 
@@ -1808,7 +1824,7 @@ class Connection {
             // then finally, the actual reject :
             conn_log(`${user.username} wanted boardsize ${widthHeight} ${rankedUnranked}-${notificationUnit}-, not in -${config[argNameString]}- `);
             // for example : "user wanted boardsize width for ranked games -15-, not in -17,19,25-
-            return { reject: true, msg: `In your selected board size ${notification.width} x ${notification.height} (width x height), boardsize ${widthHeight.toUpperCase()} (${notificationUnit}) is not allowed for ${rankedUnranked} on this bot, please choose one of these allowed CUSTOM boardsize ${widthHeight.toUpperCase()}S values for ${rankedUnranked} : ${config[argNameString]}` };
+            return { reject: true, msg: `In your selected board size ${notification.width} x ${notification.height} (width x height), boardsize ${widthHeight.toUpperCase()} (${notificationUnit}) is not allowed ${rankedUnranked} on this bot, please choose one of these allowed CUSTOM boardsize ${widthHeight.toUpperCase()}S values for ${rankedUnranked} : ${config[argNameString]}` };
             /* for example : In your selected board size 15 x 2 (width x height), boardsize WIDTH (15) is not allowed for ranked games on this bot, please choose one of these allowed CUSTOM boardsize WIDTHS values for ranked games : 17,19,25
             */
         }

--- a/connection.js
+++ b/connection.js
@@ -322,22 +322,28 @@ class Connection {
         }
 
         if ((user.ranking < config.minrank) && !config.minrankranked && !config.minrankunranked) {
-            minmaxRankFamilyReject("minrank")
+            let result = minmaxRankFamilyReject("minrank");
+            if (result) return (result);
         }
         if ((user.ranking < config.minrankranked) && notification.ranked) {
-            minmaxRankFamilyReject("minrankranked")
+            let result = minmaxRankFamilyReject("minrankranked");
+            if (result) return (result);
         }
         if ((user.ranking < config.minrankunranked) && !notification.ranked) {
-            minmaxRankFamilyReject("minrankunranked")
+            let result = minmaxRankFamilyReject("minrankunranked");
+            if (result) return (result);
         }
         if ((user.ranking > config.maxrank) && !config.maxrankranked && !config.maxrankunranked) {
-            minmaxRankFamilyReject("maxrank")
+            let result = minmaxRankFamilyReject("maxrank")
+            if (result) return (result);
         }
         if ((user.ranking > config.maxrankranked) && notification.ranked) {
-            minmaxRankFamilyReject("maxrankranked")
+            let result = minmaxRankFamilyReject("maxrankranked");
+            if (result) return (result);
         }
         if ((user.ranking > config.maxrankunranked) && !notification.ranked) {
-            minmaxRankFamilyReject("maxrankunranked")
+            let result = minmaxRankFamilyReject("maxrankunranked");
+            if (result) return (result);
         }
 
         return { reject: false }; // OK !
@@ -425,15 +431,18 @@ class Connection {
 
         /* if square, check if square board size is allowed*/
         if (!config.allowed_boardsizes[notification.width] && !config.allow_all_boardsizes && !config.allow_custom_boardsizes && !config.boardsizesranked && !config.boardsizesunranked) {
-            genericAllowedFamiliesReject("boardsizes", notification.width);
+            let result = genericAllowedFamiliesReject("boardsizes", notification.width);
+            if (result) return (result);
         }
 
         if (!config.allowed_boardsizes_ranked[notification.width] && !config.allow_all_boardsizes_ranked && !config.allow_custom_boardsizes_ranked && notification.ranked && config.boardsizesranked) {
-            genericAllowedFamiliesReject("boardsizesranked", notification.width);
+            let result = genericAllowedFamiliesReject("boardsizesranked", notification.width);
+            if (result) return (result);
         }
 
         if (!config.allowed_boardsizes_unranked[notification.width] && !config.allow_all_boardsizes_unranked && !config.allow_custom_boardsizes_unranked && !notification.ranked && config.boardsizesunranked) {
-            genericAllowedFamiliesReject("boardsizesunranked", notification.width);
+            let result = genericAllowedFamiliesReject("boardsizesunranked", notification.width);
+            if (result) return (result);
         }
 
         // for custom board sizes, including square board sizes if width === height as well //
@@ -510,81 +519,96 @@ class Connection {
             // then, after eliminating > 9 rank difference if ranked, we consider value of min-max handicap if set
             // we eliminate all unwanted values, everything not forbidden is allowed
             if (config.minhandicap && !config.minhandicapranked && !config.minhandicapunranked && (rankDifference < config.minhandicap)) {
-                automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
+                let result = automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
+                if (result) return (result);
             }
             if (config.minhandicapranked && notification.ranked && (rankDifference < config.minhandicapranked)) {
-                automaticHandicapStoneDetectionReject("minhandicapranked", rankDifference);
+                let result = automaticHandicapStoneDetectionReject("minhandicapranked", rankDifference);
+                if (result) return (result);
             }
             if (config.minhandicapunranked && !notification.ranked && (rankDifference < config.minhandicapunranked)) {
-                automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
+                let result = automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
+                if (result) return (result);
             }
             if (config.maxhandicap && !config.maxhandicapranked && !config.maxhandicapunranked && (rankDifference > config.maxhandicap)) {
-                automaticHandicapStoneDetectionReject("maxhandicap", rankDifference);
+                let result = automaticHandicapStoneDetectionReject("maxhandicap", rankDifference);
+                if (result) return (result);
             }
             if (config.maxhandicapranked && notification.ranked && (rankDifference > config.maxhandicapranked)) {
-                automaticHandicapStoneDetectionReject("maxhandicapranked", rankDifference);
+                let result = automaticHandicapStoneDetectionReject("maxhandicapranked", rankDifference);
+                if (result) return (result);
             }
             if (config.maxhandicapunranked && !notification.ranked && (rankDifference > config.maxhandicapunranked)) {
-                automaticHandicapStoneDetectionReject("maxhandicapunranked", rankDifference);
+                let result = automaticHandicapStoneDetectionReject("maxhandicapunranked", rankDifference);
+                if (result) return (result);
             }
         }
         /***** end of automatic handicap min/max handicap limits detection ******/
 
 
         if (notification.handicap < config.minhandicap && !config.minhandicapranked && !config.minhandicapunranked) {
-            minmaxHandicapFamilyReject("minhandicap");
+            let result = minmaxHandicapFamilyReject("minhandicap");
+            if (result) return (result);
         }
         if (notification.handicap < config.minhandicapranked && notification.ranked) {
-            minmaxHandicapFamilyReject("minhandicapranked");
+            let result = minmaxHandicapFamilyReject("minhandicapranked");
+            if (result) return (result);
         }
         if (notification.handicap < config.minhandicapunranked && !notification.ranked) {
-            minmaxHandicapFamilyReject("minhandicapunranked");
+            let result = minmaxHandicapFamilyReject("minhandicapunranked");
+            if (result) return (result);
         }
         if (notification.handicap > config.maxhandicap && !config.maxhandicapranked && !config.maxhandicapunranked) {
-            minmaxHandicapFamilyReject("maxhandicap");
+            let result = minmaxHandicapFamilyReject("maxhandicap");
+            if (result) return (result);
         }
         if (notification.handicap > config.maxhandicapranked && notification.ranked) {
-            minmaxHandicapFamilyReject("maxhandicapranked");
+            let result = minmaxHandicapFamilyReject("maxhandicapranked");
+            if (result) return (result);
         }
         if (notification.handicap > config.maxhandicapunranked && !notification.ranked) {
-            minmaxHandicapFamilyReject("maxhandicapunranked");
+            let result = minmaxHandicapFamilyReject("maxhandicapunranked");
+            if (result) return (result);
         }
 
         if (!config.allowed_komis[notification.komi] && !config.allow_all_komis && !config.komisranked && !config.komisunranked) {
-            genericAllowedFamiliesReject("komis", notification.komi);
+            let result = genericAllowedFamiliesReject("komis", notification.komi);
+            if (result) return (result);
         }
-
         if (!config.allowed_komis_ranked[notification.komi] && notification.ranked && !config.allow_all_komis_ranked && config.komisranked) {
-            genericAllowedFamiliesReject("komisranked", notification.komi);
+            let result = genericAllowedFamiliesReject("komisranked", notification.komi);
+            if (result) return (result);
         }
-
         if (!config.allowed_komis_unranked[notification.komi] && !notification.ranked && !config.allow_all_komis_unranked && config.komisunranked) {
-            genericAllowedFamiliesReject("komisunranked", notification.komi);
+            let result = genericAllowedFamiliesReject("komisunranked", notification.komi);
+            if (result) return (result);
         }
 
         if (!config.allowed_speeds[t.speed] && !config.speedsranked && !config.speedsunranked) {
-            genericAllowedFamiliesReject("speeds", t.speed);
+            let result = genericAllowedFamiliesReject("speeds", t.speed);
+            if (result) return (result);
         }
-
         if (!config.allowed_speeds_ranked[t.speed] && notification.ranked && config.speedsranked) {
-            genericAllowedFamiliesReject("speedsranked", t.speed);
+            let result = genericAllowedFamiliesReject("speedsranked", t.speed);
+            if (result) return (result);
         }
-
         if (!config.allowed_speeds_unranked[t.speed] && !notification.ranked && config.speedsunranked) {
-            genericAllowedFamiliesReject("speedsunranked", t.speed);
+            let result = genericAllowedFamiliesReject("speedsunranked", t.speed);
+            if (result) return (result);
         }
 
         // note : "absolute" and/or "none" are possible, but not in defaults, see README and OPTIONS-LIST for details
         if (!config.allowed_timecontrols[t.time_control] && !config.timecontrolsranked && !config.timecontrolsunranked) { 
-            genericAllowedFamiliesReject("timecontrols", t.time_control);
+            let result = genericAllowedFamiliesReject("timecontrols", t.time_control);
+            if (result) return (result);
         }
-
         if (!config.allowed_timecontrols_ranked[t.time_control] && notification.ranked && config.timecontrolsranked) { 
-            genericAllowedFamiliesReject("timecontrolsranked", t.time_control);
+            let result = genericAllowedFamiliesReject("timecontrolsranked", t.time_control);
+            if (result) return (result);
         }
-
         if (!config.allowed_timecontrols_unranked[t.time_control] && !notification.ranked && config.timecontrolsunranked) { 
-            genericAllowedFamiliesReject("timecontrolsunranked", t.time_control);
+            let result = genericAllowedFamiliesReject("timecontrolsunranked", t.time_control);
+            if (result) return (result);
         }
 
         ////// begining of *** UHMAEAT v2.3: Universal Highly Modulable And Expandable Argv Tree ***
@@ -1000,62 +1024,81 @@ class Connection {
         ////// end of *** UHMAEAT v2.3 : Universal Highly Modulable And Expandable Argv Tree ***
 
         if (config.minperiodsblitz && (t.periods < config.minperiodsblitz) && t.speed === "blitz" && !config.minperiodsblitzranked && !config.minperiodsblitzunranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitz");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitz");
+            if (result) return (result);
         }
         if (config.minperiodsblitzranked && (t.periods < config.minperiodsblitzranked) && t.speed === "blitz" && notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitzranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitzranked");
+            if (result) return (result);
         }
         if (config.minperiodsblitzunranked && (t.periods < config.minperiodsblitzunranked) && t.speed === "blitz" && !notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitzunranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitzunranked");
+            if (result) return (result);
         }
 
         if (config.minperiodslive && (t.periods < config.minperiodslive) && t.speed === "live" && !config.minperiodsliveranked && !config.minperiodsliveunranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodslive");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodslive");
+            if (result) return (result);
         }
         if (config.minperiodsliveranked && (t.periods < config.minperiodsliveranked) && t.speed === "live" && notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsliveranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsliveranked");
+            if (result) return (result);
         }
         if (config.minperiodsliveunranked && (t.periods < config.minperiodsliveunranked) && t.speed === "live" && !notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsliveunranked");
-        }
-        if (config.minperiodscorr && (t.periods < config.minperiodscorr) && t.speed === "correspondence" && !config.minperiodscorrranked && !config.minperiodscorrunranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorr");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsliveunranked");
+            if (result) return (result);
         }
 
+        if (config.minperiodscorr && (t.periods < config.minperiodscorr) && t.speed === "correspondence" && !config.minperiodscorrranked && !config.minperiodscorrunranked) {
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorr");
+            if (result) return (result);
+        }
         if (config.minperiodscorrranked && (t.periods < config.minperiodscorrranked) && t.speed === "correspondence" && notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorrranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorrranked");
+            if (result) return (result);
         }
         if (config.minperiodscorrunranked && (t.periods < config.minperiodscorrunranked) && t.speed === "correspondence" && !notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorrunranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorrunranked");
+            if (result) return (result);
         }
+
         if (config.maxperiodsblitz && (t.periods > config.maxperiodsblitz) && t.speed === "blitz" && !config.maxperiodsblitzranked && !config.maxperiodsblitzunranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitz");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitz");
+            if (result) return (result);
         }
         if (config.maxperiodsblitzranked && (t.periods > config.maxperiodsblitzranked) && t.speed === "blitz" && notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitzranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitzranked");
+            if (result) return (result);
         }
         if (config.maxperiodsblitzunranked && (t.periods > config.maxperiodsblitzunranked) && t.speed === "blitz" && !notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitzunranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitzunranked");
+            if (result) return (result);
         }
 
         if (config.maxperiodslive && (t.periods > config.maxperiodslive) && t.speed === "live" && !config.maxperiodsliveranked && !config.maxperiodsliveunranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodslive");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodslive");
+            if (result) return (result);
         }
         if (config.maxperiodsliveranked && (t.periods > config.maxperiodsliveranked) && t.speed === "live" && notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsliveranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsliveranked");
+            if (result) return (result);
         }
         if (config.maxperiodsliveunranked && (t.periods > config.maxperiodsliveunranked) && t.speed === "live" && !notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsliveunranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsliveunranked");
+            if (result) return (result);
         }
 
         if (config.maxperiodscorr && (t.periods > config.maxperiodscorr) && t.speed === "correspondence" && !config.maxperiodscorrranked && !config.maxperiodscorrunranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorr");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorr");
+            if (result) return (result);
         }
         if (config.maxperiodscorrranked && (t.periods > config.maxperiodscorrranked) && t.speed === "correspondence" && notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorrranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorrranked");
+            if (result) return (result);
         }
         if (config.maxperiodscorrunranked && (t.periods > config.maxperiodscorrunranked) && t.speed === "correspondence" && !notification.ranked) {
-            minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorrunranked");
+            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorrunranked");
+            if (result) return (result);
         }
 
         ////// begining of *** UHMAEAT v2.3: Universal Highly Modulable And Expandable Argv Tree ***

--- a/connection.js
+++ b/connection.js
@@ -288,14 +288,11 @@ class Connection {
         let user = notification.user;
 
         if (config.banned_users[user.username] || config.banned_users[user.id]) {
-            let result = bannedFamilyReject("bans");
-            if (result) return (result);
+            return bannedFamilyReject("bans");
         } else if (notification.ranked && (config.banned_users_ranked[user.username] || config.banned_users_ranked[user.id])) {
-            let result = bannedFamilyReject("bansranked");
-            if (result) return (result);
+            return bannedFamilyReject("bansranked");
         } else if (!notification.ranked && (config.banned_users_unranked[user.username] || config.banned_users_unranked[user.id])) {
-            let result = bannedFamilyReject("bansunranked");
-            if (result) return (result);
+            return bannedFamilyReject("bansunranked");
         }
 
         if (config.proonly && !user.professional) {
@@ -322,28 +319,22 @@ class Connection {
         }
 
         if ((user.ranking < config.minrank) && !config.minrankranked && !config.minrankunranked) {
-            let result = minmaxRankFamilyReject("minrank");
-            if (result) return (result);
+            return minmaxRankFamilyReject("minrank");
         }
         if ((user.ranking < config.minrankranked) && notification.ranked) {
-            let result = minmaxRankFamilyReject("minrankranked");
-            if (result) return (result);
+            return minmaxRankFamilyReject("minrankranked");
         }
         if ((user.ranking < config.minrankunranked) && !notification.ranked) {
-            let result = minmaxRankFamilyReject("minrankunranked");
-            if (result) return (result);
+            return minmaxRankFamilyReject("minrankunranked");
         }
         if ((user.ranking > config.maxrank) && !config.maxrankranked && !config.maxrankunranked) {
-            let result = minmaxRankFamilyReject("maxrank")
-            if (result) return (result);
+            return minmaxRankFamilyReject("maxrank")
         }
         if ((user.ranking > config.maxrankranked) && notification.ranked) {
-            let result = minmaxRankFamilyReject("maxrankranked");
-            if (result) return (result);
+            return minmaxRankFamilyReject("maxrankranked");
         }
         if ((user.ranking > config.maxrankunranked) && !notification.ranked) {
-            let result = minmaxRankFamilyReject("maxrankunranked");
-            if (result) return (result);
+            return minmaxRankFamilyReject("maxrankunranked");
         }
 
         return { reject: false }; // OK !
@@ -432,73 +423,58 @@ class Connection {
         // for square board sizes only //
         /* if not square*/
         if (notification.width !== notification.height && !config.allow_all_boardsizes && !config.allow_custom_boardsizes && !config.boardsizesranked && !config.boardsizesunranked) {
-            let result = boardsizeNotificationIsNotSquareReject("boardsizes");
-            if (result) return (result);
+            return boardsizeNotificationIsNotSquareReject("boardsizes");
         }
         if (notification.width !== notification.height && !config.allow_all_boardsizes_ranked && !config.allow_custom_boardsizes_ranked && notification.ranked) {
-            let result = boardsizeNotificationIsNotSquareReject("boardsizesranked");
-            if (result) return (result);
+            return boardsizeNotificationIsNotSquareReject("boardsizesranked");
         }
         if (notification.width !== notification.height && !config.allow_all_boardsizes_unranked && !config.allow_custom_boardsizes_unranked && !notification.ranked) {
-            let result = boardsizeNotificationIsNotSquareReject("boardsizesunranked");
-            if (result) return (result);
+            return boardsizeNotificationIsNotSquareReject("boardsizesunranked");
         }
 
         /* if square, check if square board size is allowed*/
         if (!config.allowed_boardsizes[notification.width] && !config.allow_all_boardsizes && !config.allow_custom_boardsizes && !config.boardsizesranked && !config.boardsizesunranked) {
-            let result = genericAllowedFamiliesReject("boardsizes", notification.width);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("boardsizes", notification.width);
         }
         if (!config.allowed_boardsizes_ranked[notification.width] && !config.allow_all_boardsizes_ranked && !config.allow_custom_boardsizes_ranked && notification.ranked && config.boardsizesranked) {
-            let result = genericAllowedFamiliesReject("boardsizesranked", notification.width);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("boardsizesranked", notification.width);
         }
         if (!config.allowed_boardsizes_unranked[notification.width] && !config.allow_all_boardsizes_unranked && !config.allow_custom_boardsizes_unranked && !notification.ranked && config.boardsizesunranked) {
-            let result = genericAllowedFamiliesReject("boardsizesunranked", notification.width);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("boardsizesunranked", notification.width);
         }
 
         // for custom board sizes, including square board sizes if width === height as well //
         /* if custom, check width */
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizewidths[notification.width] && !config.boardsizewidthsranked && !config.boardsizewidthsunranked) {
-            let result = customBoardsizeWidthsHeightsReject("boardsizewidths");
-            if (result) return (result);
+            return customBoardsizeWidthsHeightsReject("boardsizewidths");
         }
         if (!config.allow_all_boardsizes_ranked && config.allow_custom_boardsizes_ranked && !config.allowed_custom_boardsizewidths_ranked[notification.width] && notification.ranked && config.boardsizewidthsranked) {
-            let result = customBoardsizeWidthsHeightsReject("boardsizewidthsranked");
-            if (result) return (result);
+            return customBoardsizeWidthsHeightsReject("boardsizewidthsranked");
         }
         if (!config.allow_all_boardsizes_unranked && config.allow_custom_boardsizes_unranked && !config.allowed_custom_boardsizewidths_unranked[notification.width] && !notification.ranked && config.boardsizewidthsunranked) {
-            let result = customBoardsizeWidthsHeightsReject("boardsizewidthsunranked");
-            if (result) return (result);
+            return customBoardsizeWidthsHeightsReject("boardsizewidthsunranked");
         }
 
         /* if custom, check height */
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizeheights[notification.height] && !config.boardsizeheightsranked && !config.boardsizeheightsunranked) {
-            let result = customBoardsizeWidthsHeightsReject("boardsizeheights");
-            if (result) return (result);
+            return customBoardsizeWidthsHeightsReject("boardsizeheights");
         }
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizeheights[notification.height] && notification.ranked && config.boardsizeheightsranked) {
-            let result = customBoardsizeWidthsHeightsReject("boardsizeheightsranked");
-            if (result) return (result);
+            return customBoardsizeWidthsHeightsReject("boardsizeheightsranked");
         }
         if (!config.allow_all_boardsizes && config.allow_custom_boardsizes && !config.allowed_custom_boardsizeheights[notification.height] && !notification.ranked && config.boardsizeheightsunranked) {
-            let result = customBoardsizeWidthsHeightsReject("boardsizeheightsunranked");
-            if (result) return (result);
+            return customBoardsizeWidthsHeightsReject("boardsizeheightsunranked");
         }
         /******** end of BOARDSIZES *********/
 
         if (notification.handicap === -1 && config.noautohandicap) {
-            let result = noAutohandicapReject("noautohandicap");
-            if (result) return (result);
+            return noAutohandicapReject("noautohandicap");
 	}
         if (notification.handicap === -1 && config.noautohandicapranked && notification.ranked) {
-            let result = noAutohandicapReject("noautohandicapranked");
-            if (result) return (result);
+            return noAutohandicapReject("noautohandicapranked");
 	}
         if (notification.handicap === -1 && config.noautohandicapunranked && !notification.ranked) {
-            let result = noAutohandicapReject("noautohandicapunranked");
-            if (result) return (result);
+            return noAutohandicapReject("noautohandicapunranked");
 	}
 
         /***** automatic handicap min/max handicap limits detection ******/
@@ -526,96 +502,75 @@ class Connection {
             // then, after eliminating > 9 rank difference if ranked, we consider value of min-max handicap if set
             // we eliminate all unwanted values, everything not forbidden is allowed
             if (config.minhandicap && !config.minhandicapranked && !config.minhandicapunranked && (rankDifference < config.minhandicap)) {
-                let result = automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
-                if (result) return (result);
+                return automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
             }
             if (config.minhandicapranked && notification.ranked && (rankDifference < config.minhandicapranked)) {
-                let result = automaticHandicapStoneDetectionReject("minhandicapranked", rankDifference);
-                if (result) return (result);
+                return automaticHandicapStoneDetectionReject("minhandicapranked", rankDifference);
             }
             if (config.minhandicapunranked && !notification.ranked && (rankDifference < config.minhandicapunranked)) {
-                let result = automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
-                if (result) return (result);
+                return automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
             }
             if (config.maxhandicap && !config.maxhandicapranked && !config.maxhandicapunranked && (rankDifference > config.maxhandicap)) {
-                let result = automaticHandicapStoneDetectionReject("maxhandicap", rankDifference);
-                if (result) return (result);
+                return automaticHandicapStoneDetectionReject("maxhandicap", rankDifference);
             }
             if (config.maxhandicapranked && notification.ranked && (rankDifference > config.maxhandicapranked)) {
-                let result = automaticHandicapStoneDetectionReject("maxhandicapranked", rankDifference);
-                if (result) return (result);
+                return automaticHandicapStoneDetectionReject("maxhandicapranked", rankDifference);
             }
             if (config.maxhandicapunranked && !notification.ranked && (rankDifference > config.maxhandicapunranked)) {
-                let result = automaticHandicapStoneDetectionReject("maxhandicapunranked", rankDifference);
-                if (result) return (result);
+                return automaticHandicapStoneDetectionReject("maxhandicapunranked", rankDifference);
             }
         }
         /***** end of automatic handicap min/max handicap limits detection ******/
 
 
         if (notification.handicap < config.minhandicap && !config.minhandicapranked && !config.minhandicapunranked) {
-            let result = minmaxHandicapFamilyReject("minhandicap");
-            if (result) return (result);
+            return minmaxHandicapFamilyReject("minhandicap");
         }
         if (notification.handicap < config.minhandicapranked && notification.ranked) {
-            let result = minmaxHandicapFamilyReject("minhandicapranked");
-            if (result) return (result);
+            return minmaxHandicapFamilyReject("minhandicapranked");
         }
         if (notification.handicap < config.minhandicapunranked && !notification.ranked) {
-            let result = minmaxHandicapFamilyReject("minhandicapunranked");
-            if (result) return (result);
+            return minmaxHandicapFamilyReject("minhandicapunranked");
         }
         if (notification.handicap > config.maxhandicap && !config.maxhandicapranked && !config.maxhandicapunranked) {
-            let result = minmaxHandicapFamilyReject("maxhandicap");
-            if (result) return (result);
+            return minmaxHandicapFamilyReject("maxhandicap");
         }
         if (notification.handicap > config.maxhandicapranked && notification.ranked) {
-            let result = minmaxHandicapFamilyReject("maxhandicapranked");
-            if (result) return (result);
+            return minmaxHandicapFamilyReject("maxhandicapranked");
         }
         if (notification.handicap > config.maxhandicapunranked && !notification.ranked) {
-            let result = minmaxHandicapFamilyReject("maxhandicapunranked");
-            if (result) return (result);
+            return minmaxHandicapFamilyReject("maxhandicapunranked");
         }
 
         if (!config.allowed_komis[notification.komi] && !config.allow_all_komis && !config.komisranked && !config.komisunranked) {
-            let result = genericAllowedFamiliesReject("komis", notification.komi);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("komis", notification.komi);
         }
         if (!config.allowed_komis_ranked[notification.komi] && notification.ranked && !config.allow_all_komis_ranked && config.komisranked) {
-            let result = genericAllowedFamiliesReject("komisranked", notification.komi);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("komisranked", notification.komi);
         }
         if (!config.allowed_komis_unranked[notification.komi] && !notification.ranked && !config.allow_all_komis_unranked && config.komisunranked) {
-            let result = genericAllowedFamiliesReject("komisunranked", notification.komi);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("komisunranked", notification.komi);
         }
 
         if (!config.allowed_speeds[t.speed] && !config.speedsranked && !config.speedsunranked) {
-            let result = genericAllowedFamiliesReject("speeds", t.speed);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("speeds", t.speed);
         }
         if (!config.allowed_speeds_ranked[t.speed] && notification.ranked && config.speedsranked) {
-            let result = genericAllowedFamiliesReject("speedsranked", t.speed);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("speedsranked", t.speed);
         }
         if (!config.allowed_speeds_unranked[t.speed] && !notification.ranked && config.speedsunranked) {
-            let result = genericAllowedFamiliesReject("speedsunranked", t.speed);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("speedsunranked", t.speed);
         }
 
         // note : "absolute" and/or "none" are possible, but not in defaults, see README and OPTIONS-LIST for details
         if (!config.allowed_timecontrols[t.time_control] && !config.timecontrolsranked && !config.timecontrolsunranked) { 
-            let result = genericAllowedFamiliesReject("timecontrols", t.time_control);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("timecontrols", t.time_control);
         }
         if (!config.allowed_timecontrols_ranked[t.time_control] && notification.ranked && config.timecontrolsranked) { 
-            let result = genericAllowedFamiliesReject("timecontrolsranked", t.time_control);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("timecontrolsranked", t.time_control);
         }
         if (!config.allowed_timecontrols_unranked[t.time_control] && !notification.ranked && config.timecontrolsunranked) { 
-            let result = genericAllowedFamiliesReject("timecontrolsunranked", t.time_control);
-            if (result) return (result);
+            return genericAllowedFamiliesReject("timecontrolsunranked", t.time_control);
         }
 
         ////// begining of *** UHMAEAT v2.3: Universal Highly Modulable And Expandable Argv Tree ***
@@ -1031,81 +986,63 @@ class Connection {
         ////// end of *** UHMAEAT v2.3 : Universal Highly Modulable And Expandable Argv Tree ***
 
         if (config.minperiodsblitz && (t.periods < config.minperiodsblitz) && t.speed === "blitz" && !config.minperiodsblitzranked && !config.minperiodsblitzunranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitz");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitz");
         }
         if (config.minperiodsblitzranked && (t.periods < config.minperiodsblitzranked) && t.speed === "blitz" && notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitzranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitzranked");
         }
         if (config.minperiodsblitzunranked && (t.periods < config.minperiodsblitzunranked) && t.speed === "blitz" && !notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitzunranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsblitzunranked");
         }
 
         if (config.minperiodslive && (t.periods < config.minperiodslive) && t.speed === "live" && !config.minperiodsliveranked && !config.minperiodsliveunranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodslive");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodslive");
         }
         if (config.minperiodsliveranked && (t.periods < config.minperiodsliveranked) && t.speed === "live" && notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsliveranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsliveranked");
         }
         if (config.minperiodsliveunranked && (t.periods < config.minperiodsliveunranked) && t.speed === "live" && !notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsliveunranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodsliveunranked");
         }
 
         if (config.minperiodscorr && (t.periods < config.minperiodscorr) && t.speed === "correspondence" && !config.minperiodscorrranked && !config.minperiodscorrunranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorr");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorr");
         }
         if (config.minperiodscorrranked && (t.periods < config.minperiodscorrranked) && t.speed === "correspondence" && notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorrranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorrranked");
         }
         if (config.minperiodscorrunranked && (t.periods < config.minperiodscorrunranked) && t.speed === "correspondence" && !notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorrunranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("minperiodscorrunranked");
         }
 
         if (config.maxperiodsblitz && (t.periods > config.maxperiodsblitz) && t.speed === "blitz" && !config.maxperiodsblitzranked && !config.maxperiodsblitzunranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitz");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitz");
         }
         if (config.maxperiodsblitzranked && (t.periods > config.maxperiodsblitzranked) && t.speed === "blitz" && notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitzranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitzranked");
         }
         if (config.maxperiodsblitzunranked && (t.periods > config.maxperiodsblitzunranked) && t.speed === "blitz" && !notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitzunranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsblitzunranked");
         }
 
         if (config.maxperiodslive && (t.periods > config.maxperiodslive) && t.speed === "live" && !config.maxperiodsliveranked && !config.maxperiodsliveunranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodslive");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodslive");
         }
         if (config.maxperiodsliveranked && (t.periods > config.maxperiodsliveranked) && t.speed === "live" && notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsliveranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsliveranked");
         }
         if (config.maxperiodsliveunranked && (t.periods > config.maxperiodsliveunranked) && t.speed === "live" && !notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsliveunranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodsliveunranked");
         }
 
         if (config.maxperiodscorr && (t.periods > config.maxperiodscorr) && t.speed === "correspondence" && !config.maxperiodscorrranked && !config.maxperiodscorrunranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorr");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorr");
         }
         if (config.maxperiodscorrranked && (t.periods > config.maxperiodscorrranked) && t.speed === "correspondence" && notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorrranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorrranked");
         }
         if (config.maxperiodscorrunranked && (t.periods > config.maxperiodscorrunranked) && t.speed === "correspondence" && !notification.ranked) {
-            let result = minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorrunranked");
-            if (result) return (result);
+            return minmaxPeriodsBlitzlivecorrFamilyReject("maxperiodscorrunranked");
         }
 
         ////// begining of *** UHMAEAT v2.3: Universal Highly Modulable And Expandable Argv Tree ***

--- a/connection.js
+++ b/connection.js
@@ -470,20 +470,66 @@ class Connection {
         }
         /******** end of BOARDSIZES *********/
 
-        if (config.noautohandicap && notification.handicap === -1 && !config.noautohandicapranked && !config.noautohandicapunranked) {
-            conn_log("no autohandicap, rejecting challenge") ;
+        if (notification.handicap === -1 && config.noautohandicap) {
+            conn_log("no autohandicap");
             return { reject: true, msg: "For easier bot management, automatic handicap is disabled on this bot, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones" };
 	}
 
-        if (config.noautohandicapranked && notification.handicap === -1 && notification.ranked) {
-            conn_log("no autohandicap for ranked games, rejecting challenge") ;
+        if (notification.handicap === -1 && config.noautohandicapranked && notification.ranked) {
+            conn_log("no autohandicap for ranked games");
             return { reject: true, msg: "For easier bot management, automatic handicap is disabled for ranked games on this bot, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones" };
 	}
 
-        if (config.noautohandicapunranked && notification.handicap === -1 && !notification.ranked) {
-            conn_log("no autohandicap for unranked games, rejecting challenge") ;
+        if (notification.handicap === -1 && config.noautohandicapunranked && !notification.ranked) {
+            conn_log("no autohandicap for unranked games");
             return { reject: true, msg: "For easier bot management, automatic handicap is disabled for unranked games on this bot, please manually select the number of handicap stones you want in -custom handicap-, for example 2 handicap stones" };
 	}
+
+        /***** automatic handicap min/max handicap limits detection ******/
+
+        // below is a fix of automatic handicap bypass issue
+        // by manually calculating handicap stones number
+        // then calculate if it is within set min/max
+        // limits set by botadmin
+
+        // TODO : for all the code below, replace "fakerank" with 
+        // notification.bot.ranking (server support for bot ranking detection 
+        // in gtp2ogs)
+
+        if (notification.handicap === -1 && !config.noautohandicap && !config.noautohandicapranked && !config.noautohandicapunranked) {
+            let rankDifference = Math.abs(Math.trunc(user.ranking) - Math.trunc(config.fakerank));
+            // adding a trunk because a 5.9k (6k) vs 6.1k (7k) is 0.2 rank difference,
+            // but it is in fact a still a 6k vs 7k = Math.abs(6-7) = 1 rank difference game
+
+            // first, if ranked game, we eliminate > 9 rank difference
+            if (notification.ranked && (rankDifference > 9)) {
+                conn_log("Rank difference > 9 in a ranked game would be 10+ handicap stones, not allowed");
+                return {reject: true, msg: "Rank difference between you and this bot is " + rankDifference + "\n The difference is too big to play a ranked game with handicap (max is 9 handicap for ranked games), try unranked handicap or manually reduce the number of handicap stones in -custom handicap-"};
+            }
+
+            // then, after eliminating > 9 rank difference if ranked, we consider value of min-max handicap if set
+            // we eliminate all unwanted values, everything not forbidden is allowed
+            if (config.minhandicap && !config.minhandicapranked && !config.minhandicapunranked && (rankDifference < config.minhandicap)) {
+                automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
+            }
+            if (config.minhandicapranked && notification.ranked && (rankDifference < config.minhandicapranked)) {
+                automaticHandicapStoneDetectionReject("minhandicapranked", rankDifference);
+            }
+            if (config.minhandicapunranked && !notification.ranked && (rankDifference < config.minhandicapunranked)) {
+                automaticHandicapStoneDetectionReject("minhandicap", rankDifference);
+            }
+            if (config.maxhandicap && !config.maxhandicapranked && !config.maxhandicapunranked && (rankDifference > config.maxhandicap)) {
+                automaticHandicapStoneDetectionReject("maxhandicap", rankDifference);
+            }
+            if (config.maxhandicapranked && notification.ranked && (rankDifference > config.maxhandicapranked)) {
+                automaticHandicapStoneDetectionReject("maxhandicapranked", rankDifference);
+            }
+            if (config.maxhandicapunranked && !notification.ranked && (rankDifference > config.maxhandicapunranked)) {
+                automaticHandicapStoneDetectionReject("maxhandicapunranked", rankDifference);
+            }
+        }
+        /***** end of automatic handicap min/max handicap limits detection ******/
+
 
         if (notification.handicap < config.minhandicap && !config.minhandicapranked && !config.minhandicapunranked) {
             minmaxHandicapFamilyReject("minhandicap");
@@ -1609,6 +1655,31 @@ class Connection {
             // then finally, the actual reject :
             conn_log(`${user.username} wanted ${t.periods} periods, ${minMax} periods ${rankedUnranked} is ${config[argNameString]}, needs to be ${increaseDecrease}d`);
             return { reject: true, msg: `${minMax} periods ${rankedUnranked} is ${config[argNameString]}, please ${increaseDecrease} the number of periods` };
+        }
+
+        function automaticHandicapStoneDetectionReject (argNameString, rankDifference) {
+            // first, we define rankedUnranked and minMax depending on argNameString
+            let rankedUnranked = "";
+            // if argNameString does not include "ranked" or "unranked", we keep default value for rankedunranked
+            if (argNameString.includes("ranked") && !argNameString.includes("unranked")) {
+                rankedUnranked = "for ranked games";
+            } else if (argNameString.includes("unranked")) {
+                rankedUnranked = "for unranked games";
+            }
+
+            let minMax = "";
+            let increaseDecrease = "";
+            if (argNameString.includes("min")) {
+                minMax = "Min";
+                increaseDecrease = "increase";
+            } else if (argNameString.includes("max")) {
+                minMax = "Max";
+                increaseDecrease = "reduce";
+            }
+
+            // then finally, the actual reject :
+            conn_log(`Automatic handicap ${rankedUnranked} was set to ${rankDifference} stones, but ${minMax} handicap ${rankedUnranked} is ${config[argNameString]} stones`);
+            return { reject: true, msg: `Your automatic handicap ${rankedUnranked} was automatically set to ${rankDifference} stones based on rank difference between you and this bot,\nBut ${minMax} handicap ${rankedUnranked} is ${config[argNameString]} stones \nPlease ${increaseDecrease} the number of handicap stones ${rankedUnranked} in -custom handicap-` };
         }
 
         function pluralFamilyStringToSingularString(plural) {

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -425,6 +425,11 @@ Thank you message to appear in chat at end of game (ex: "Thank you for playing")
 recommended to use `--noautohandicap` as well, see 
 [#165](https://github.com/online-go/gtp2ogs/pull/165) for details
 
+note 2 : currently, since "automatic" handicap returns the server 
+value `notification.handicap` `-1`, using `--minhandicap 0` will 
+also disable automatic handicap (because `-1 < 0`), regardless of 
+the number of automatic handicap stones
+
 #### maxhandicap
   ```--maxhandicap```  Max handicap for all games
 
@@ -444,6 +449,21 @@ recommended to use `--noautohandicap` as well, see
   
   ```--noautohandicapunranked``` Do not allow handicap to be set to 
 -automatic- for unranked games
+
+#### fakerank
+  ```--fakerank``` Temporary manual bot ranking input by bot admin 
+to fix autohandicap bypass issue, by manualy counting min and max 
+number of handicap stones allowed if handicap is "automatic"
+
+This is a temporary fix until server provides bot ranking detection
+on gtp2ogs
+
+for example ```--fakerank 6d``` and ```--minhandicap 0 --maxhandicap 4``` 
+will allow automatic handicap only for opponents ranked between 2d-6d for 
+automatic handicap, but players of any rank (even 25k or 9d+) will be 
+notified that they are still able to play up to 4 handicap stones games 
+by going in -custom handicap- and manually inputting the number of 
+handicap stones
 
 #### nopause
   ```--nopause```  Do not allow games to be paused


### PR DESCRIPTION
@anoek @roy7 @Dorus @windo 

rewrote #165 on top of #181 

while waiting for server support for bot ranking detection, 
using a reasonable approximation of bot ranking with
for example `--fakerank 6d`

examples of bypass issue : 

example :

opponent 3d vs bot 7d with --maxhandicap 2 :
automatic handicap -> a 7d-3d = 4 stones
so a 4 stone handicap starts even though
--maxhandicap is set to 2

example 2 :

opponent 1k vs bot 7d with
--minhandicap 2 --maxhandicap 5 :
automatic handicap -> a 7d-1k = 8 stones
so a 8 stone handicap starts even though
--maxhandicap is set to 8
(even (0 max) handicap is bypassed when
handicap is automatic)
the same behaviour also happens for minhandicap
as well
note : --minhandicap 0 disables automatic handicap
(because -1 < 0)

read commit message for details :+1: 

didnt test it, but i hope it works :+1: 