### PR TITLE
fix minmaxrank typo

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -365,7 +365,7 @@ class Connection {
 
             // then finally, the actual reject :
             conn_log(`${user.username} ranking ${humanReadableUserRank} too ${lowHigh} ${rankedUnranked}: ${minMax} ${rankedUnranked}is ${humanReadableMinmaxRank}`);
-            return { reject: true, msg: `${minMax} rank ${rankedUnranked}is ${config[argNameString]}, your rank is too ${lowHigh} ${rankedUnranked}` };
+            return { reject: true, msg: `${minMax} rank ${rankedUnranked}is ${humanReadableMinmaxRank}, your rank is too ${lowHigh} ${rankedUnranked}` };
         }
 
         function bannedFamilyReject(argNameString) {


### PR DESCRIPTION
this PR is on top of latest devel 

fixing a minor typo introduced while converting old code to a function :+1: 
read commit message for details

didnt test, but should work :100: 