### PR TITLE
Remove dumping game log message.

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -232,7 +232,6 @@ class Connection {
         }
     }
     dumpStatus() {
-        conn_log('Dumping status of all connected games');
         for (let game_id in this.connected_games) {
             let game = this.connected_games[game_id];
             let msg = [];
@@ -259,7 +258,6 @@ class Connection {
             msg.push('bot.failed=' + game.bot.failed);
             conn_log(...msg);
         }
-        conn_log('Dump complete');
     }
     deleteNotification(notification) { /* {{{ */
         this.socket.emit('notification/delete', this.auth({notification_id: notification.id}), () => {


### PR DESCRIPTION
Removing the 2 lines we see every 15 minutes. This seems a bit excessive outside testing.

I left in 3 calls to `conn_log(...msg);` as i think those might be useful for debugging purposes.

There are two alternatives here. We could get rid of the entire dumpStatus function and trust the other logic to work. We could also leave the "Dumping status of all connected games" message in, but only display it if there are actual connected games.