### PR TITLE
refactor time management in bot.js

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -179,7 +179,7 @@ class Bot {
                                           + state.time_control.stones_per_period);
 
             for (const [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
-                                                                   ["white", state.clock.white_time, white_offset] ]) {
+                                                                     ["white", state.clock.white_time, white_offset] ]) {
                 const color_timeleft = Math.max(Math.floor(color_time.thinking_time - color_offset), 0);
                 const time_settings_two_three =
                     color_timeleft > 0 ? `${color_timeleft} 0`
@@ -228,7 +228,7 @@ class Bot {
                                             + " 1");
 
             for (const [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
-                                                                   ["white", state.clock.white_time, white_offset] ]) {
+                                                                     ["white", state.clock.white_time, white_offset] ]) {
                 if (color_time) {
                     const color_timeleft = Math.max(Math.floor((color_time - now) / 1000 - color_offset), 0);
                     const color_string_opposite = color_string === "black" ? "white" : "black";
@@ -253,7 +253,7 @@ class Bot {
             //
 
             for (const [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
-                                                                   ["white", state.clock.white_time, white_offset] ]) {
+                                                                     ["white", state.clock.white_time, white_offset] ]) {
                 const color_timeleft = Math.max(Math.floor(color_time.thinking_time - color_offset), 0);
                 this.command(`time_left ${color_string} ${color_timeleft} 0`);
             }
@@ -263,7 +263,7 @@ class Bot {
                                           + " 0 0");
 
             for (const [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
-                                                                   ["white", state.clock.white_time, white_offset] ]) {
+                                                                     ["white", state.clock.white_time, white_offset] ]) {
                 const color_timeleft = Math.max(Math.floor(color_time.thinking_time - color_offset), 0);
                 this.command(`time_left ${color_string} ${color_timeleft} 0`);
             }

--- a/bot.js
+++ b/bot.js
@@ -160,7 +160,7 @@ class Bot {
         //
         if (config.noclock) return;
 
-        //let now = state.clock.now ? state.clock.now : (Date.now() - this.conn.clock_drift);
+        //const now = state.clock.now ? state.clock.now : (Date.now() - this.conn.clock_drift);
         const now = Date.now() - this.conn.clock_drift;
 
         const offset = ((this.firstmove===true ? config.startupbuffer : 0) + now - state.clock.last_move) / 1000;
@@ -178,7 +178,7 @@ class Bot {
                                           + " "
                                           + state.time_control.stones_per_period);
 
-            for (let [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
+            for (const [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
                                                                    ["white", state.clock.white_time, white_offset] ]) {
                 const color_timeleft = Math.max(Math.floor(color_time.thinking_time - color_offset), 0);
                 const time_settings_two_three =
@@ -200,9 +200,9 @@ class Bot {
             // OGS enforces the number of periods is always 1 or greater. Let's pretend the final period is a Canadian Byoyomi of 1 stone.
             // This lets the bot know it can use the full period per move, not try to fit the rest of the game into the time left.
             //
-            let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time
+            const black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time
                 - black_offset + (state.clock.black_time.periods - 1) * state.time_control.period_time), 0);
-            let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time
+            const white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time
                 - white_offset + (state.clock.white_time.periods - 1) * state.time_control.period_time), 0);
 
             this.command("time_settings " + (state.time_control.main_time + (state.time_control.periods - 1) * state.time_control.period_time)
@@ -227,7 +227,7 @@ class Bot {
             this.command("time_settings 0 " + state.time_control.per_move
                                             + " 1");
 
-            for (let [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
+            for (const [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
                                                                    ["white", state.clock.white_time, white_offset] ]) {
                 if (color_time) {
                     const color_timeleft = Math.max(Math.floor((color_time - now) / 1000 - color_offset), 0);
@@ -252,7 +252,7 @@ class Bot {
             // But subtract the increment time above to avoid timeouts.
             //
 
-            for (let [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
+            for (const [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
                                                                    ["white", state.clock.white_time, white_offset] ]) {
                 const color_timeleft = Math.max(Math.floor(color_time.thinking_time - color_offset), 0);
                 this.command(`time_left ${color_string} ${color_timeleft} 0`);
@@ -262,7 +262,7 @@ class Bot {
             this.command("time_settings " + state.time_control.total_time
                                           + " 0 0");
 
-            for (let [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
+            for (const [color_string, color_time, color_offset] of [ ["black", state.clock.black_time, black_offset],
                                                                    ["white", state.clock.white_time, white_offset] ]) {
                 const color_timeleft = Math.max(Math.floor(color_time.thinking_time - color_offset), 0);
                 this.command(`time_left ${color_string} ${color_timeleft} 0`);

--- a/bot.js
+++ b/bot.js
@@ -185,9 +185,9 @@ class Bot {
             // OGS enforces the number of periods is always 1 or greater. Let's pretend the final period is a Canadian Byoyomi of 1 stone.
             // This lets the bot know it can use the full period per move, not try to fit the rest of the game into the time left.
             //
-            let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time
+            const black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time
                 - black_offset + (state.clock.black_time.periods - 1) * state.time_control.period_time), 0);
-            let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time
+            const white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time
                 - white_offset + (state.clock.white_time.periods - 1) * state.time_control.period_time), 0);
 
             this.command("time_settings " + (state.time_control.main_time + (state.time_control.periods - 1) * state.time_control.period_time) + " "
@@ -207,8 +207,8 @@ class Bot {
         } else if (state.time_control.system === 'canadian') {
             // Canadian Byoyomi is the only time controls GTP v2 officially supports.
             // 
-            let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
-            let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
+            const black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
+            const white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
 
             this.command("time_settings " + state.time_control.main_time + " "
                 + state.time_control.period_time + " " + state.time_control.stones_per_period);
@@ -224,14 +224,14 @@ class Bot {
             // This should let the bot know a good approximation of how to handle 
             // the time remaining.
             //
-            let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
-            let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
+            const black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
+            const white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
 
             this.command("time_settings " + (state.time_control.initial_time - state.time_control.time_increment)
                 + " " + state.time_control.time_increment + " 1");
 
-            // Always tell the bot we are in main time ('0') so it doesn't try to think all of timeleft per move. But
-            // subtract the increment time above to avoid timeouts.
+            // Always tell the bot we are in main time ('0') so it doesn't try to think all of timeleft per move.
+            // But subtract the increment time above to avoid timeouts.
             //
             this.command("time_left black " + black_timeleft + " 0");
             this.command("time_left white " + white_timeleft + " 0");
@@ -243,24 +243,25 @@ class Bot {
 
             if (state.clock.black_time)
             {
-                let black_timeleft = Math.max( Math.floor((state.clock.black_time - now)/1000 - black_offset), 0);
+                const black_timeleft = Math.max( Math.floor((state.clock.black_time - now)/1000 - black_offset), 0);
                 this.command("time_left black " + black_timeleft + " 1");
                 this.command("time_left white 1 1");
             } else {
-                let white_timeleft = Math.max( Math.floor((state.clock.white_time - now)/1000 - white_offset), 0);
+                const white_timeleft = Math.max( Math.floor((state.clock.white_time - now)/1000 - white_offset), 0);
                 this.command("time_left black 1 1");
                 this.command("time_left white " + white_timeleft + " 1");
             }
 
         } else if (state.time_control.system === 'absolute') {
-            let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
-            let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
+            const black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
+            const white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
 
             this.command("time_settings " + state.time_control.total_time + " 0 0");
 
             this.command("time_left black " + black_timeleft + " 0");
             this.command("time_left white " + white_timeleft + " 0");
         }
+        
         // OGS doesn't actually send 'none' time control type
         //
         /* else if (state.time_control.system === 'none') {

--- a/config.js
+++ b/config.js
@@ -65,8 +65,6 @@ exports.updateFromArgv = function() {
         .default('startupbuffer', 5)
         .describe('timeout', 'Disconnect from a game after this many seconds (if set)')
         .default('timeout', 0)
-        // TODO: Test known_commands for kgs-time_settings to set this, and remove the command line option
-        .describe('kgstime', 'Set this if bot understands the kgs-time_settings command')
         .describe('showboard', 'Set this if bot understands the showboard GTP command, and if you want to display the showboard output')
         .describe('persist', 'Bot process remains running between moves')
         .describe('noclock', 'Do not send any clock/time data to the bot')
@@ -484,11 +482,17 @@ function testDeprecatedArgv(optimistArgv, komisFamilyNameString) {
         ["speedunranked", "speedsunranked"],
         ["timecontrol", "timecontrols"],
         ["timecontrolranked", "timecontrolsranked"],
-        ["timecontrolunranked", "timecontrolsunranked"]
+        ["timecontrolunranked", "timecontrolsunranked"],
+        ["kgstime", false]
         ];
-    for (let [oldName, newName] of deprecatedArgv) {
+    for (const [oldName, newName] of deprecatedArgv) {
         if (optimistArgv[oldName]) {
-            console.log(`Deprecated: --${oldName} is no longer supported, use --${newName} instead.`);
+            const begining = `Deprecated: --${oldName} is no longer supported`;
+            if (newName) {
+                throw new `${begining}, use --${newName} instead.`;
+            } else {
+                throw new `${begining}, see all supported options list https://github.com/online-go/gtp2ogs/blob/devel/docs/OPTIONS-LIST.md`;
+            }
         }
     }
     for (let komisGRUArg of familyArrayNamesGRU(komisFamilyNameString)) {

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -131,9 +131,6 @@ available on first move (if set)
 #### timeout
 ```--timeout``` Disconnect from a game after this many seconds (if set)
 
-#### kgstime
-  ```--kgstime```  Set this if bot understands the kgs-time_settings command
-
 #### showboard
   ```--showboard```  Set this if bot understands the showboard 
 GTP command, and if you want to display the showboard output


### PR DESCRIPTION
OGS already has its own implementation of timesettings,
and it seems very few bot admins actually use the kgs time
settings option.
Our tests.js also runs fine without it.

This also simplifies the code by removing many conditionnal
assignments.

what do you think ?