### PR TITLE
If we get a duplicate gamedata and nothing has changed, ignore it

### DIFF
--- a/game.js
+++ b/game.js
@@ -39,6 +39,16 @@ class Game {
         this.socket.on(`game/${game_id}/gamedata`, (gamedata) => {
             if (!this.connected) return;
 
+            const gamedataChanged = false;
+
+            if (this.state) {
+                gamedataChanged = (JSON.stringify(this.state) !== JSON.stringify(gamedata));
+
+                // If the gamedata is idential to current state, it's a duplicate. Ignore it and do nothing.
+                this.log('Ignoring gamedata that matches current state');
+                if (!gamedataChanged) return;
+            }
+
             //this.log("Gamedata:", JSON.stringify(gamedata, null, 4));
 
             const prev_phase = (this.state ? this.state.phase : null);
@@ -80,8 +90,6 @@ class Game {
             // restart the bot by killing it here if another gamedata comes in. There normally should only be one
             // before we process any moves, and makeMove() is where a new Bot is created.
             //
-            const gamedataChanged = (JSON.stringify(this.state) !== JSON.stringify(gamedata));
-
             if (this.bot && gamedataChanged) {
                 this.log("Killing bot because of gamedata change after bot was started");
 

--- a/game.js
+++ b/game.js
@@ -41,7 +41,7 @@ class Game {
 
             const gamedataChanged = this.state ? (JSON.stringify(this.state) !== JSON.stringify(gamedata)) : false;
 
-            if (this.state & !gamedataChanged) {
+            if (this.state && !gamedataChanged) {
                 // If the gamedata is idential to current state, it's a duplicate. Ignore it and do nothing.
                 this.log('Ignoring gamedata that matches current state');
                 return;

--- a/game.js
+++ b/game.js
@@ -41,8 +41,9 @@ class Game {
 
             const gamedataChanged = this.state ? (JSON.stringify(this.state) !== JSON.stringify(gamedata)) : false;
 
-            if (this.state && !gamedataChanged) {
-                // If the gamedata is idential to current state, it's a duplicate. Ignore it and do nothing.
+            if (this.state && !gamedataChanged && this.bot && !this.bot.dead) {
+                // If the gamedata is idential to current state, it's a duplicate. Ignore it and do nothing, unless no
+                // bot is running.
                 this.log('Ignoring gamedata that matches current state');
                 return;
             }

--- a/game.js
+++ b/game.js
@@ -39,14 +39,12 @@ class Game {
         this.socket.on(`game/${game_id}/gamedata`, (gamedata) => {
             if (!this.connected) return;
 
-            let gamedataChanged = false;
+            const gamedataChanged = this.state ? (JSON.stringify(this.state) !== JSON.stringify(gamedata)) : false;
 
-            if (this.state) {
-                gamedataChanged = (JSON.stringify(this.state) !== JSON.stringify(gamedata));
-
+            if (this.state & !gamedataChanged) {
                 // If the gamedata is idential to current state, it's a duplicate. Ignore it and do nothing.
                 this.log('Ignoring gamedata that matches current state');
-                if (!gamedataChanged) return;
+                return;
             }
 
             //this.log("Gamedata:", JSON.stringify(gamedata, null, 4));

--- a/game.js
+++ b/game.js
@@ -39,7 +39,7 @@ class Game {
         this.socket.on(`game/${game_id}/gamedata`, (gamedata) => {
             if (!this.connected) return;
 
-            const gamedataChanged = false;
+            let gamedataChanged = false;
 
             if (this.state) {
                 gamedataChanged = (JSON.stringify(this.state) !== JSON.stringify(gamedata));

--- a/game.js
+++ b/game.js
@@ -41,11 +41,36 @@ class Game {
 
             const gamedataChanged = this.state ? (JSON.stringify(this.state) !== JSON.stringify(gamedata)) : false;
 
+            // If the gamedata is idential to current state, it's a duplicate. Ignore it and do nothing, unless
+            // bot is not running.
+            //
             if (this.state && !gamedataChanged && this.bot && !this.bot.dead) {
-                // If the gamedata is idential to current state, it's a duplicate. Ignore it and do nothing, unless no
-                // bot is running.
                 this.log('Ignoring gamedata that matches current state');
                 return;
+            }
+
+            // If server has issues it might send us a new gamedata packet and not a move event. We could try to
+            // check if we're missing a move and send it to bot out of gamedata. For now as a safe fallback just
+            // restart the bot by killing it here if another gamedata comes in. There normally should only be one
+            // before we process any moves, and makeMove() is where a new Bot is created.
+            //
+            if (this.bot && gamedataChanged) {
+                this.log("Killing bot because of gamedata change after bot was started");
+
+                if (config.DEBUG) {
+                    this.log('Previously seen gamedata:', this.state);
+                    this.log('New gamedata:', gamedata);
+                }
+
+                this.ensureBotKilled();
+
+                if (this.processing) {
+                    this.processing = false;
+                    --Game.moves_processing;
+                    if (config.corrqueue && this.state.time_control.speed === "correspondence") {
+                        --Game.corr_moves_processing;
+                    }
+                }
             }
 
             //this.log("Gamedata:", JSON.stringify(gamedata, null, 4));
@@ -81,30 +106,6 @@ class Game {
                     this.opponent_evenodd = this.state.moves.length % 2;
                 } else {
                     this.opponent_evenodd = (this.state.moves.length + 1) % 2;
-                }
-            }
-
-            // If server has issues it might send us a new gamedata packet and not a move event. We could try to
-            // check if we're missing a move and send it to bot out of gamedata. For now as a safe fallback just
-            // restart the bot by killing it here if another gamedata comes in. There normally should only be one
-            // before we process any moves, and makeMove() is where a new Bot is created.
-            //
-            if (this.bot && gamedataChanged) {
-                this.log("Killing bot because of gamedata change after bot was started");
-
-                if (config.DEBUG) {
-                    this.log('Previously seen gamedata:', this.state);
-                    this.log('New gamedata:', gamedata);
-                }
-
-                this.ensureBotKilled();
-
-                if (this.processing) {
-                    this.processing = false;
-                    --Game.moves_processing;
-                    if (config.corrqueue && this.state.time_control.speed === "correspondence") {
-                        --Game.corr_moves_processing;
-                    }
                 }
             }
 


### PR DESCRIPTION
This can happen if connection timeout is slow and we re-request gamedata, but it was already on the way?

Timeouts were added in https://github.com/online-go/gtp2ogs/commit/9693202d2dc91ceeeaf812429ddddcad7473c257 but it seems the errors in https://github.com/online-go/gtp2ogs/issues/256 were when we re-requested gamedata and got it a second time, but issued a move command to server before processing the 2nd gamedata packet.