### PR TITLE
Send quit command before marking bot dead

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -506,8 +506,9 @@ class Bot {
     kill() {
         this.log("Stopping bot");
         this.ignore = true;  // Prevent race conditions / inconsistencies. Could be in the middle of genmove ...
-        this.dead = true;
+        // "quit" needs to be sent before we toggle this.dead since command() checks the status of this.dead
         this.command("quit");
+        this.dead = true;
         if (this.proc) {
             this.proc.kill();
             setTimeout(() => {


### PR DESCRIPTION
Will actually start telling bots to quit cleanly (oops), and get rid of the error message in debug log about trying to send a command to a dead bot.