### PR TITLE
hide jwt in debug, hide apikey and jwt only if they exist, keep track of notification to spot unexpected elements we receive from server

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -560,11 +560,6 @@ class Connection {
 function request(method, host, port, path, data) {
     return new Promise((resolve, reject) => {
         if (config.DEBUG) {
-            // Keeping a backup of old copy syntax just in case.
-            // const noapidata  = JSON.parse(JSON.stringify(data));
-            // noapidata.apikey = "hidden";
-            // noapidata.jwt    = "hidden";
-
             // ES6 offers shallow copy syntax using spread
             const noapidata = { ...data };
             if ("apikey" in noapidata) noapidata.apikey = "hidden";

--- a/connection.js
+++ b/connection.js
@@ -476,6 +476,11 @@ class Connection {
         const c0 = this.checkChallenge(notification);
         const rejectmsg = (c0.msg ? c0.msg : "");
 
+        if (config.DEBUG) {
+            conn_log(`Keeping track of notification to detect any unexpected receipt:`
+                    + `\n${JSON.stringify(notification)}`);
+        }
+
         const handi = (notification.handicap > 0 ? `H${notification.handicap}` : "");
         const accepting = (c0.reject ? "Rejecting" : "Accepting");
         conn_log(`${accepting} challenge from ${notification.user.username} `

--- a/connection.js
+++ b/connection.js
@@ -566,7 +566,9 @@ function request(method, host, port, path, data) {
             // noapidata.jwt    = "hidden";
 
             // ES6 offers shallow copy syntax using spread
-            const noapidata = { ...data, apikey: "hidden", jwt: "hidden" };
+            const noapidata = { ...data };
+            if ("apikey" in noapidata) noapidata.apikey = "hidden";
+            if ("jwt" in noapidata)    noapidata.jwt    = "hidden";
             console.debug(method, host, port, path, noapidata);
         }
 

--- a/connection.js
+++ b/connection.js
@@ -560,12 +560,13 @@ class Connection {
 function request(method, host, port, path, data) {
     return new Promise((resolve, reject) => {
         if (config.DEBUG) {
-            /* Keeping a backup of old copy syntax just in case.
-            /  const noapidata = JSON.parse(JSON.stringify(data));
-            /  noapidata.apikey = "hidden";*/
+            // Keeping a backup of old copy syntax just in case.
+            // const noapidata  = JSON.parse(JSON.stringify(data));
+            // noapidata.apikey = "hidden";
+            // noapidata.jwt    = "hidden";
 
             // ES6 offers shallow copy syntax using spread
-            const noapidata = { ...data, apikey: "hidden" };
+            const noapidata = { ...data, apikey: "hidden", jwt: "hidden" };
             console.debug(method, host, port, path, noapidata);
         }
 

--- a/connection.js
+++ b/connection.js
@@ -67,6 +67,7 @@ class Connection {
             socket.emit('bot/id', {'id': config.username}, (obj) => {
                 this.bot_id = obj.id;
                 this.jwt = obj.jwt;
+                this.showed_jwt = false;
                 if (!this.bot_id) {
                     console.error(`ERROR: Bot account is unknown to the system: ${config.username}`);
                     process.exit();
@@ -562,8 +563,16 @@ function request(method, host, port, path, data) {
         if (config.DEBUG) {
             // ES6 offers shallow copy syntax using spread
             const noapidata = { ...data };
-            if ("apikey" in noapidata) noapidata.apikey = "hidden";
-            if ("jwt" in noapidata)    noapidata.jwt    = "hidden";
+            if ("apikey" in noapidata) {
+                noapidata.apikey = "hidden";
+            }
+            if (this.showed_jwt) {
+                if ("jwt" in noapidata) {
+                    noapidata.jwt = "already showed once";
+                }
+            } else {
+                this.showed_jwt = true;
+            }
             console.debug(method, host, port, path, noapidata);
         }
 


### PR DESCRIPTION
tested to work

edit: for now we'll just hide jwt, and see later how we want to modify debug information in the future

jwt hidden:
(just hide jwt and keep everything else in debug api data as it is)

![jwt hidden](https://user-images.githubusercontent.com/38690718/82711265-25623d00-9c85-11ea-9e19-058f83818995.png)
