### PR TITLE
Add hide() unhide() setHidden() helper functions

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -555,6 +555,15 @@ class Connection {
         clearInterval(this.notification_connect_interval);
         clearInterval(this.corr_queue_interval);
     }
+    setHidden(setting) {
+        socket.emit('bot/hidden', !!setting);
+    }
+    hide() {
+        socket.emit('bot/hidden', true);
+    }
+    unhide() {
+        socket.emit('bot/hidden', false);
+    }
 }
 
 function request(method, host, port, path, data) {

--- a/connection.js
+++ b/connection.js
@@ -555,9 +555,6 @@ class Connection {
         clearInterval(this.notification_connect_interval);
         clearInterval(this.corr_queue_interval);
     }
-    setHidden(setting) {
-        this.socket.emit('bot/hidden', !!setting);
-    }
     hide() {
         this.socket.emit('bot/hidden', true);
     }

--- a/connection.js
+++ b/connection.js
@@ -556,13 +556,13 @@ class Connection {
         clearInterval(this.corr_queue_interval);
     }
     setHidden(setting) {
-        socket.emit('bot/hidden', !!setting);
+        this.socket.emit('bot/hidden', !!setting);
     }
     hide() {
-        socket.emit('bot/hidden', true);
+        this.socket.emit('bot/hidden', true);
     }
     unhide() {
-        socket.emit('bot/hidden', false);
+        this.socket.emit('bot/hidden', false);
     }
 }
 


### PR DESCRIPTION
For future use by the various clock/time rejection stuff. We could set timers to auto hide an unhide or at least hide if we're shut off for good, so we don't appear in server drop down any more.