### PR TITLE
add --mingamesplayed --mingamesplayedranked --mingamesplayedunranked

### DIFF
--- a/config.js
+++ b/config.js
@@ -132,6 +132,9 @@ exports.updateFromArgv = function() {
         .describe('noautohandicap', 'Do not allow handicap to be set to -automatic-')
         .describe('noautohandicapranked', 'Do not allow handicap to be set to -automatic- for ranked games')
         .describe('noautohandicapunranked', 'Do not allow handicap to be set to -automatic- for unranked games')
+        .describe('mingamesplayed', 'Do not accept challenges from players who played less ranked games than specified minimum number (too new players)')
+        .describe('mingamesplayedranked', 'Do not accept ranked challenges from players who played less ranked games than specified minimum number (too new players)')
+        .describe('mingamesplayedunranked', 'Do not accept unranked challenges from players who played less ranked games than specified minimum number (too new players)')
         .describe('minrank', 'Minimum opponent rank to accept (ex: 15k)')
         .string('minrank')
         .describe('minrankranked', 'Minimum opponent rank to accept for ranked games (ex: 15k)')
@@ -237,6 +240,7 @@ exports.updateFromArgv = function() {
         { name: "nopause" },
         { name: "nopauseonweekends" },
         { name: "noautohandicap" },
+        { name: "mingamesplayed" },
         { name: "minrank" },
         { name: "maxrank" },
         { name: "minhandicap" },

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -479,6 +479,26 @@ max:
 
 **important note**: see [fakerank](#fakerank).
 
+#### mingamesplayed
+
+This option can be useful to avoid spammers and bot abusers, who generally
+create new accounts to repeat their abuse.
+
+`games played` is the number of RANKED games played, so a new user could still
+abuse your bot by playing enough fair ranked games, then spamming unranked challenges
+where he uses a bot, but in this case no harm is done to our bot so it should be fine.
+
+A reasonable value seems to be something between 10 and 20.
+
+  `--mingamesplayed` Do not accept challenges from players who played less
+ranked games than specified minimum number (too new players)
+
+  `--mingamesplayedranked` Do not accept ranked challenges from players who
+played less ranked games than specified minimum number (too new players)
+
+  `--mingamesplayed` Do not accept unranked challenges from players who
+played less ranked games than specified minimum number (too new players)
+
 #### min/max rank
 
 min:

--- a/test/checkChallenge.test.js
+++ b/test/checkChallenge.test.js
@@ -162,11 +162,183 @@ describe('Challenges', () => {
 
   });
 
+  describe('Min games played', () => {
+
+
+    it ('reject min games played too low (0)', () => {
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 0;
+
+      config.mingamesplayed = 10;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: true, msg: 'It looks like your account is still new on OGS, this bot will be open to your user account after you play more games.' }));
+
+    });
+    it ('reject min games played too low', () => {
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 9;
+
+      config.mingamesplayed = 10;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: true, msg: 'It looks like your account is still new on OGS, this bot will be open to your user account after you play more games.' }));
+
+    });
+
+    it ('accept min games played edge min', () => {
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 10;
+
+      config.mingamesplayed = 10;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+
+    });
+
+    it ('accept min games played high enough', () => {
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 11;
+
+      config.mingamesplayed = 10;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+
+    });
+
+  });
+
+  describe('General Ranked Unranked Min games played precedence rules', () => {
+
+    // do not exhaustively retest everything, just making sure the ranked unranked precedence is respected
+
+    it ('reject min games played based on ranked arg too low (no unranked arg)', () => {
+      const notification = base_challenge({ ranked: true });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 0;
+
+      config.mingamesplayedranked = 20;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: true, msg: 'It looks like your account is still new on OGS, this bot will be open to your user account for ranked games after you play more games.' }));
+
+    });
+
+    it ('reject min games played based on unranked arg too low (no ranked arg)', () => {
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 0;
+
+      config.mingamesplayedunranked = 5;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: true, msg: 'It looks like your account is still new on OGS, this bot will be open to your user account for unranked games after you play more games.' }));
+
+    });
+
+    it ('reject min games played based on ranked arg too low', () => {
+      const notification = base_challenge({ ranked: true });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 19;
+
+      config.mingamesplayedranked = 20;
+      config.mingamesplayedunranked = 5;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: true, msg: 'It looks like your account is still new on OGS, this bot will be open to your user account for ranked games after you play more games.' }));
+
+    });
+
+    it ('reject min games played based on unranked arg too low', () => {
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 4;
+
+      config.mingamesplayedranked = 20;
+      config.mingamesplayedunranked = 5;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: true, msg: 'It looks like your account is still new on OGS, this bot will be open to your user account for unranked games after you play more games.' }));
+
+    });
+
+    it ('accept min games played based on ranked arg (no unranked arg)', () => {
+      const notification = base_challenge({ ranked: true });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 20;
+
+      config.mingamesplayedranked = 20;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+
+    });
+
+    it ('accept min games played based on unranked arg (no ranked arg)', () => {
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 5;
+
+      config.mingamesplayedunranked = 5;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+
+    });
+
+    it ('accept min games played based on ranked arg', () => {
+      const notification = base_challenge({ ranked: true });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 20;
+
+      config.mingamesplayedranked = 20;
+      config.mingamesplayedunranked = 5;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+
+    });
+
+    it ('accept min games played based on unranked arg', () => {
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ranking
+      notification.user.ratings.overall.games_played = 5;
+
+      config.mingamesplayedranked = 20;
+      config.mingamesplayedunranked = 5;
+
+      const result = conn.checkChallengeUser(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+
+    });
+
+  });
+
   describe('Min Max Rank', () => {
 
     it('reject user ranking too low', () => {
 
-      const notification = base_challenge({ ranked: false, user: { ranking: 10 } }); // "20k"
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ratings.overall.games_played
+      notification.user.ranking = 10; // "20k"
 
       config.minrank = 17;
       config.maxrank = 32;
@@ -179,7 +351,9 @@ describe('Challenges', () => {
 
     it('accept user ranking edge min', () => {
 
-      const notification = base_challenge({ ranked: false, user: { ranking: 17 } }); // "13k"
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ratings.overall.games_played
+      notification.user.ranking = 17; // "13k"
 
       config.minrank = 17;
       config.maxrank = 32;
@@ -192,7 +366,9 @@ describe('Challenges', () => {
 
     it('accept user ranking between min and max', () => {
 
-      const notification = base_challenge({ ranked: false, user: { ranking: 25 } }); // "5k"
+      const notification = base_challenge({ ranked: false });
+      // cannot override user directly: it would delete required property notification.user.ratings.overall.games_played
+      notification.user.ranking = 25; // "5k"
 
       config.minrank = 17;
       config.maxrank = 32;
@@ -204,7 +380,9 @@ describe('Challenges', () => {
     });
 
     it('accept user ranking edge max', () => {
-      const notification = base_challenge({ ranked: false, user: { ranking: 32 } }); // "3d"
+      const notification = base_challenge({ ranked: false });
+      // cannot override user.ranking property directly: it would delete required property notification.user.ratings.overall.games_played
+      notification.user.ranking = 32; // "3d"
 
       config.minrank = 17;
       config.maxrank = 32;
@@ -217,7 +395,9 @@ describe('Challenges', () => {
 
     it('reject user ranking too high', () => {
 
-      const notification = base_challenge({ ranked: false, user: { ranking: 35 } }); // "6d"
+      const notification = base_challenge({ ranked: false });
+      // cannot override user.ranking property directly: it would delete required property notification.user.ratings.overall.games_played
+      notification.user.ranking = 35; // "6d"
 
       config.minrank = 17;
       config.maxrank = 32;
@@ -230,7 +410,9 @@ describe('Challenges', () => {
 
     it('reject user ranking too high (9d+)', () => {
 
-      const notification = base_challenge({ ranked: false, user: { ranking: 41 } }); // "12d"
+      const notification = base_challenge({ ranked: false });
+      // cannot override user.ranking property directly: it would delete required property notification.user.ratings.overall.games_played
+      notification.user.ranking = 41; // "12d"
 
       config.minrank = 17;
       config.maxrank = 32;
@@ -243,7 +425,9 @@ describe('Challenges', () => {
 
     it('reject user ranking too high (pro)', () => {
 
-      const notification = base_challenge({ ranked: false, user: { ranking: 37 } }); // "1p" (1p" = "8d")
+      const notification = base_challenge({ ranked: false });
+      // cannot override user.ranking property directly: it would delete required property notification.user.ratings.overall.games_played
+      notification.user.ranking = 37; // "1p" (1p" = "8d")
 
       config.minrank = 17;
       config.maxrank = 32;

--- a/test/test.js
+++ b/test/test.js
@@ -168,7 +168,14 @@ function base_challenge(overrides) {
         user: {
             id: 2,
             username: 'human',
-            rating: 1000.0,
+            ratings: {
+                overall: {
+                    deviation: 150.0,
+                    rating: 1000.0,
+                    games_played: 5,
+                    volatility: 0.25
+                }
+            },
             ranking: 10.0,
             professional: false,
         },


### PR DESCRIPTION
edit 2: rebased onto devel

it was tested to work on official OGS (does not work on beta OGS because ranking is disabled and everyone has rating 1500)

edit:
adding the successful test result

```Shell
Jun 12 18:26:43   connection.js:369              {"overall":{"deviation":131.5028681227713,"rating":2632.2964640809596,"games_played":10,"volatility":0.06019623766801121}}
Jun 12 18:26:43   connection.js:721              #  Number of ranked games played by this user is 10, it is below minimum 999999, user is too new (mingamesplayed)
Jun 12 18:26:43   connection.js:721              #  Rejecting challenge from meta-金毛测试-20b-handicap (6d)  [19x19]  id = 24647722
Jun 12 18:26:43   connection.js:631              POST online-go.com 443 /api/v1/me/challenges/7663664 {
  delete: true,
  message: 'It looks like your account is still new on OGS, this bot will be open to your user account after you play more games.',
  apikey: 'hidden',
  bot_id: 785246,
  player_id: 785246,
  jwt: ''
}
```