### PR TITLE
minor formatting: skip lines in test.js

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -797,22 +797,31 @@ describe("Pv should work", () => {
     function testPv(pvCode, fileName, chatBody) {
         stub_console();
         sinon.useFakeTimers();
+
         let fake_socket = new FakeSocket();
         let fake_api = new FakeAPI();
         fake_api.request({ path: '/foo' }, () => { });
         sinon.stub(https, 'request').callsFake(fake_api.request);
+
         let fake_gtp = new FakeGTP();
         sinon.stub(child_process, 'spawn').returns(fake_gtp);
+
         let conn = new connection.Connection(() => { return fake_socket; }, config);
+
         const game = sinon.spy();
         game.sendChat = sinon.spy();
         game.processing = true;
         game.state = { width: 19, moves: { length: 2 } };
+
         config.ogspv = pvCode;
+
         new Bot(conn, game, config.bot_command);
+
         fake_gtp.stderr.emit('data', fs.readFileSync(`./test/${fileName}.txt`));
+
         assert.equal(game.sendChat.callCount, 1);
         assert.ok(game.sendChat.firstCall.calledWith(chatBody, 3, 'malkovich'));
+        
         conn.terminate();
     }
 });


### PR DESCRIPTION
added lines skip to match this block of code:
<https://github.com/online-go/gtp2ogs/blob/devel/test/test.js#L741-L769>