### PR TITLE
add sanity check: non-correspondence challenges cannot have pausing on weekends

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -331,11 +331,19 @@ class Connection {
             return { reject: true, msg };
         }
 
-        // Sanity check: OGS enforces rules to be chinese regardless of user's choice.
+        // Sometimes server sends us live challenges with pauses on weekends enabled.
+        if (notification.time_control.pause_on_weekends && notification.time_control.speed !== "correspondence") {
+            err(`Unhandled pause on weekends in non-correspondence challenge (${notification.time_control.speed}).`);
+            const msg = `There was an unexpected error: your ${notification.time_control.speed} challenge`
+                        + ` has pause on weekends, but this is only possible for correspondence games`
+                        + `, please try again.`;
+            return { reject: true, msg };
+        }
+
+        // OGS enforces rules to be chinese regardless of user's choice.
         if (!notification.rules.includes("chinese")) {
-            err(`Unhandled rules: ${notification.rules}`);
-            const msg = `The ${notification.rules} rules are not allowed on this bot, `
-                        + `please choose allowed rules, for example chinese rules.`;
+            err(`Unhandled rules: ${notification.rules}.`);
+            const msg = `Games against bots on OGS can only be chinese rules.`;
             return { reject: true, msg };
         }
 

--- a/connection.js
+++ b/connection.js
@@ -318,7 +318,7 @@ class Connection {
         if (!knownSpeeds.includes(notification.time_control.speed)) {
             err(`Unknown speed ${notification.time_control.speed}.`);
             const msg = `Unknown speed ${notification.time_control.speed}`
-                        + `, cannot check challenge, please contact my bot admin.`;
+                        + `, cannot check challenge, please try again.`;
             return { reject: true, msg };
         }
 
@@ -327,7 +327,7 @@ class Connection {
         if (!knownTimecontrols.includes(notification.time_control.time_control)) {
             err(`Unknown time control ${notification.time_control.time_control}.`);
             const msg = `Unknown time control ${notification.time_control.time_control}`
-                        + `, cannot check challenge, please contact my bot admin.`;
+                        + `, cannot check challenge, please try again.`;
             return { reject: true, msg };
         }
 
@@ -777,7 +777,7 @@ function getReject(reason) {
 
 function getCheckedKeyInObjReject(k) {
     err(`Missing key ${k}.`);
-    const msg = `Missing key ${k}, cannot check challenge, please contact my bot admin.`;
+    const msg = `Missing key ${k}, cannot check challenge, please try again.`;
     return { reject: true, msg };
 }
 

--- a/test/checkChallenge.test.js
+++ b/test/checkChallenge.test.js
@@ -79,7 +79,7 @@ describe('Challenges', () => {
     
     const result = conn.checkChallenge(notification);
     
-    assert.deepEqual(result, ({ reject: true, msg: 'Missing key user, cannot check challenge, please contact my bot admin.' }));
+    assert.deepEqual(result, ({ reject: true, msg: 'Missing key user, cannot check challenge, please try again.' }));
     });
 
     it('reject non-correspondence challenge that has pause on weekends', () => {

--- a/test/checkChallenge.test.js
+++ b/test/checkChallenge.test.js
@@ -82,6 +82,38 @@ describe('Challenges', () => {
     assert.deepEqual(result, ({ reject: true, msg: 'Missing key user, cannot check challenge, please contact my bot admin.' }));
     });
 
+    it('reject non-correspondence challenge that has pause on weekends', () => {
+      const notification = base_challenge({ time_control: { system: "fischer", time_control: "fischer", speed: "live", pause_on_weekends: true, time_increment: 1, initial_time: 59, max_time: 59 } });
+
+      const result = conn.checkChallengeSanityChecks(notification);
+
+      assert.deepEqual(result, ({ reject: true, msg: 'There was an unexpected error: your live challenge has pause on weekends, but this is only possible for correspondence games, please try again.' }));
+    });
+
+    it('accept non-correspondence challenge that does not have pause on weekends', () => {
+      const notification = base_challenge({ time_control: { system: "fischer", time_control: "fischer", speed: "live", pause_on_weekends: false, time_increment: 1, initial_time: 59, max_time: 59 } });
+
+      const result = conn.checkChallengeSanityChecks(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+    });
+
+    it('accept correspondence challenge that has pause on weekends', () => {
+      const notification = base_challenge({ time_control: { system: "fischer", time_control: "fischer", speed: "correspondence", pause_on_weekends: true, time_increment: 1, initial_time: 59, max_time: 59 } });
+
+      const result = conn.checkChallengeSanityChecks(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+    });
+
+    it('accept correspondence challenge that does not have pause on weekends', () => {
+      const notification = base_challenge({ time_control: { system: "fischer", time_control: "fischer", speed: "correspondence", pause_on_weekends: false, time_increment: 1, initial_time: 59, max_time: 59 } });
+
+      const result = conn.checkChallengeSanityChecks(notification);
+
+      assert.deepEqual(result, ({ reject: false }));
+    });
+
   });
 
   describe('Bans', () => {


### PR DESCRIPTION
edit2: i just rebased this, ready to merge

this fixes the issue @sanderland noticed in https://online-go.com/game/view/24994942, where live challenges could strangely have pausing on weekends