### PR TITLE
upgrade package-lock.json: fix lodash Prototype Pollution vulnerability (1523)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1674,9 +1674,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.differencewith": {


### PR DESCRIPTION
lodash vulnerability was fixed 2 days ago:

https://www.npmjs.com/advisories/1523
https://www.npmjs.com/package/lodash

There are now 0 vulnerabilities after npm audit!! :tada: 

![fix loash prototype pollution](https://user-images.githubusercontent.com/38690718/87142694-343c9780-c2a5-11ea-84df-2d1f509d29f5.png)
