### PR TITLE
fix getArgv.js missing in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "console.js",
     "constants.js",
     "game.js",
+    "getArgv.js",
     "gtp2ogs.js",
     "pv.js",
     "gtp/**",


### PR DESCRIPTION
this is urgent and i carelessly missed it

spotted while writing tests in #332 , and also fixed in #332 

thankfully there was no getArgv.js file in 6.0.1 so devel users who use git clone should be safe https://github.com/online-go/gtp2ogs/tree/6.0.1