### PR TITLE
move check_rejectnew to a local function in connection.js, add unit testing for rejectnew, rejectnewfile, rejectnewmsg

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,16 +3,12 @@
 // see: https://github.com/online-go/gtp2ogs/blob/devel/docs/DEV.md#no-console-eslint-rule-in-configjs
 /* eslint-disable no-console */
 
-const fs = require('fs');
-
 const { getArgNamesGRU } = require('./options/getArgNamesGRU');
 const { getOptionName } = require('./options/getOptionName');
 const { getRankedUnranked } = require('./options/getRankedUnranked');
 const { getRankedUnrankedUnderscored } = require('./options/getRankedUnrankedUnderscored');
 
 const { droppedOptions, ogsPvAIs, rankedUnrankedOptions } = require('./constants');
-
-exports.check_rejectnew = function() {};
 
 exports.banned_users = {};
 exports.banned_users_ranked = {};
@@ -53,6 +49,7 @@ exports.updateFromArgv = function(argv) {
     testDroppedArgv(droppedOptions, argv);
     testConflictingOptions("rankedonly", "unrankedonly", argv);
     testConflictingOptions("persist", "persistnoncorr", argv);
+    testConflictingOptions("rejectnew", "rejectnewfile", argv);
     ensureSupportedOgspvAI(argv.ogspv, ogsPvAIs);
     testRankedUnrankedOptions(rankedUnrankedOptions, argv);
 
@@ -110,12 +107,6 @@ exports.updateFromArgv = function(argv) {
         // A bot never accepting new games shouldn't be appearing in the dropdown, polite to our users.
         exports.hidden = true;
     }
-    exports.check_rejectnew = function()
-    {
-        if (argv.rejectnew)  return true;
-        if (argv.rejectnewfile && fs.existsSync(argv.rejectnewfile))  return true;
-        return false;
-    };
     exports.bot_command = argv._;
 
     // 2) specific ranked/unranked options exports

--- a/connection.js
+++ b/connection.js
@@ -1,5 +1,6 @@
 // vim: tw=120 softtabstop=4 shiftwidth=4
 
+const fs = require('fs');
 const http = require('http');
 const https = require('https');
 const querystring = require('querystring');
@@ -383,7 +384,7 @@ class Connection {
     //
     checkChallengeBot(notification) {
 
-        if (config.check_rejectnew()) {
+        if (check_rejectnew()) {
             conn_log("Not accepting new games (rejectnew).");
             return { reject: true, msg: config.rejectnewmsg };
         }
@@ -794,6 +795,12 @@ function processCheckedTimeSettingsKeysRejectResult(timecontrol, keys, notif) {
         const resultNotificationKeysTimeSettings = getCheckedKeysInObjRejectResult(keys, notif);
         if (resultNotificationKeysTimeSettings) return resultNotificationKeysTimeSettings;
     }
+}
+
+function check_rejectnew() {
+    if (config.rejectnew)  return true;
+    if (config.rejectnewfile && fs.existsSync(config.rejectnewfile))  return true;
+    return false;
 }
 
 function getCheckedArgName(optionName, notificationRanked) {

--- a/constants.js
+++ b/constants.js
@@ -47,6 +47,16 @@ const droppedOptions = [
 
 const ogsPvAIs = ["LeelaZero", "Sai", "KataGo", "PhoenixGo", "Leela"];
 
+const rootOptionsDefaults = {
+    host: 'online-go.com',
+    maxconnectedgames: 20,
+    maxconnectedgamesperuser: 3,
+    port: 443,
+    rejectnewmsg: 'Currently, this bot is not accepting games, try again later',
+    startupbuffer: 5,
+    timeout: 0,
+};
+
 const rankedUnrankedOptions = [
     { name: "bans" },
     { name: "boardsizes", default: "9,13,19" },
@@ -86,4 +96,4 @@ function getBLCString(optionName, rankedUnranked) {
            + `and/or --${optionName}corr${rankedUnranked}`;
 }
 
-module.exports = { droppedOptions, ogsPvAIs, rankedUnrankedOptions };
+module.exports = { droppedOptions, ogsPvAIs, rootOptionsDefaults, rankedUnrankedOptions };

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -60,6 +60,8 @@ option if minhandicap (or ranked unranked) is used and higher than -1
 
 ## G
 
+### rejectnewmsg
+
 when using the "msg" options (`--greeting` , `--farewell` ,
 `--rejectnew --rejectnewmsg` , some special characters will
 make gtp2ogs crash, such as `!!` (two times `!`) , so test
@@ -68,6 +70,17 @@ special characters in your messages with caution
 these special characters have been tested to work on messages,
 among others:  `!` (one time `!`) , `?` , `,` , `(` , `)` ,
 `:` , `;`
+
+### rejectnewfile
+
+Location can either be absolute (ex: ~/ or /home/myUsername/) or
+relative (for relative paths, it is relative to your current shell path
+(ex: if your shell is in ~/ and your rejectnew file is in ~/gtp2ogs/rejectnewfiles,
+do ./rejectnewfiles/rejectnew-file.txt, ex2: if your shell is in ~/gtp2ogs_logs
+and your rejectnewfile is in ~/gtp2ogs_rejectnewfiles/, do
+../gtp2ogs_logs/rejectnewfiles/rejectnew-file.txt)
+
+Rejectnewfile is checked again at every challenge, can use for load-balancing)
 
 ## H
 

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -135,10 +135,12 @@ reject message
 if you add the rejectnewmsg option, Reject all new challenges with a
 customized message instead of the default message.
 
-`--rejectnewfile ~/rejectnew.status` Reject new challenges if file
+`--rejectnewfile ~/rejectnew-file.txt` Reject new challenges if file
 (ex: rejectnew.status, rejectnew-file.txt, etc.) exists at specified location.
 
 Rejectnewfile is checked again at every challenge, can use for load-balancing)
+
+see for details [notes G](/docs/NOTES.md#g)
 
 ### debug
 

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -25,7 +25,7 @@ currently provides:
 --timeout 0
 --maxconnectedgames 20
 --maxconnectedgamesperuser 3
---rejectnewmsg "Currently, this bot is not accepting games, try again later "
+--rejectnewmsg "Currently, this bot is not accepting games, try again later"
 --boardsizes 9,13,19
 --komis automatic
 --speeds all

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -126,6 +126,8 @@ save it locally.
 
 ### rejectnew options
 
+rejectnew and rejectnewfile cannot be both used at the same time.
+
 `--rejectnew` Reject all new challenges with the default
 reject message
 
@@ -133,10 +135,10 @@ reject message
 if you add the rejectnewmsg option, Reject all new challenges with a
 customized message instead of the default message.
 
-see for details [notes G](/docs/NOTES.md#g)
+`--rejectnewfile ~/rejectnew.status` Reject new challenges if file
+(ex: rejectnew.status, rejectnew-file.txt, etc.) exists at specified location.
 
-`--rejectnewfile ~/rejectnew.status` Reject new challenges if
-file exists (checked each time, can use for load-balancing)
+Rejectnewfile is checked again at every challenge, can use for load-balancing)
 
 ### debug
 

--- a/getArgv.js
+++ b/getArgv.js
@@ -1,4 +1,4 @@
-const { ogsPvAIs } = require('./constants');
+const { ogsPvAIs, rootOptionsDefaults } = require('./constants');
 
 function getArgv() {
 
@@ -17,8 +17,8 @@ function getArgv() {
         .describe('farewellscore', 'Send the score according to the bot at the end of the game')
         .describe('rejectnew', 'Reject all new challenges with the default reject message')
         .describe('rejectnewmsg', 'Adds a customized reject message included in quote yourmessage quote')
-        .default('rejectnewmsg', 'Currently, this bot is not accepting games, try again later ')
-        .describe('rejectnewfile', 'Reject new challenges if file exists (checked each time, can use for load-balancing)')
+        .default('rejectnewmsg', rootOptionsDefaults.rejectnewmsg)
+        .describe('rejectnewfile', 'Reject new challenges if file (ex: rejectnew.status, rejectnew-file.txt, etc.) exists at specified location. Location can either be absolute (ex: ~/ or /home/myUsername/) or relative for relative paths, it is relative to your current shell path (ex: if your shell is in ~/ and your rejectnew file is in ~/gtp2ogs/rejectnewfiles, do ./rejectnewfiles/rejectnew-file.txt, ex2: if your shell is in ~/gtp2ogs_logs and your rejectnewfile is in ~/gtp2ogs_rejectnewfiles/, do ../gtp2ogs_logs/rejectnewfiles/rejectnew-file.txt')
         .describe('debug', 'Output GTP command and responses from your Go engine')
         .describe('ogspv', `Send winrate and variations for supported AIs (${ogsPvAIs.join(', ')})with supported settings`)
         .string('ogspv')
@@ -29,15 +29,15 @@ function getArgv() {
         .describe('json', 'Send and receive GTP commands in a JSON encoded format')
         .describe('beta', 'Connect to the beta server (sets ggs/rest hosts to the beta server)')
         .describe('host', 'OGS Host to connect to')
-        .default('host', 'online-go.com') // default to OGS. If --beta, host will switch to beta OGS automatically
+        .default('host', rootOptionsDefaults.host) // default to OGS. If --beta, host will switch to beta OGS automatically
         .describe('port', 'OGS Port to connect to')
-        .default('port', 443)
+        .default('port', rootOptionsDefaults.port)
         .describe('insecure', 'Do not use ssl to connect to the ggs/rest servers')
         .describe('hidden', 'Hides the botname from the OGS game -Play against computer- bot list (but it can still accept challenges)')
         .describe('startupbuffer', 'Subtract this many seconds from time available on first move')
-        .default('startupbuffer', 5)
+        .default('startupbuffer', rootOptionsDefaults.startupbuffer)
         .describe('timeout', 'Disconnect from a game after this many seconds (if set)')
-        .default('timeout', 0)
+        .default('timeout', rootOptionsDefaults.timeout)
         // TODO: Test known_commands for kgs-time_settings to set this, and remove the command line option
         .describe('kgstime', 'Set this if bot understands the kgs-time_settings command')
         .describe('showboard', 'Set this if bot understands the showboard GTP command, and if you want to display the showboard output')
@@ -48,9 +48,9 @@ function getArgv() {
         /* note: for maxconnectedgames, correspondence games are currently included
         /  in the maxconnectedgames count if you use `--persist` )*/
         .describe('maxconnectedgames', 'Maximum number of connected games for all users')
-        .default('maxconnectedgames', 20)
+        .default('maxconnectedgames', rootOptionsDefaults.maxconnectedgames)
         .describe('maxconnectedgamesperuser', 'Maximum number of connected games per user against this bot')
-        .default('maxconnectedgamesperuser', 3)
+        .default('maxconnectedgamesperuser', rootOptionsDefaults.maxconnectedgamesperuser)
         .describe('rankedonly', 'Only accept ranked matches')
         .describe('unrankedonly', 'Only accept unranked matches')
         .describe('fakerank', 'Fake bot ranking to calculate automatic handicap stones number in autohandicap (-1) based on rankDifference between fakerank and user ranking, to fix the bypass minhandicap maxhandicap issue if handicap is -automatic')

--- a/test/checkChallenge.test.js
+++ b/test/checkChallenge.test.js
@@ -286,6 +286,117 @@ describe('Challenges', () => {
    
   });
 
+  describe('Rejectnew', () => {
+
+    // rejectnew is ranked-unranked aspecific, so ranked unranked testing is minimal
+
+    it('reject all games if rejectnew is used with default rejectnewmsg', () => {
+
+      const notification = base_challenge({ ranked: false });
+
+      config.rejectnew = true;
+      
+      const result = conn.checkChallengeBot(notification);
+      
+      assert.deepEqual(result, ({ reject: true, msg: 'Currently, this bot is not accepting games, try again later' }));
+    });
+
+    it('also rejectnew in ranked games', () => {
+
+        const notification = base_challenge({ ranked: true });
+  
+        config.rejectnew = true;
+        
+        const result = conn.checkChallengeBot(notification);
+        
+        assert.deepEqual(result, ({ reject: true, msg: 'Currently, this bot is not accepting games, try again later' }));
+    });
+
+    it('reject all games if rejectnew is used with custom rejectnewmsg', () => {
+
+        const notification = base_challenge({ ranked: false });
+  
+        config.rejectnew = true;
+        config.rejectnewmsg = 'Sorry, i am not available now.';
+        
+        const result = conn.checkChallengeBot(notification);
+        
+        assert.deepEqual(result, ({ reject: true, msg: 'Sorry, i am not available now.' }));
+    });
+
+    it('do not reject game if rejectnew is not used, and rejectnewmsg is default', () => {
+
+        const notification = base_challenge({ ranked: false });
+  
+        config.rejectnew = undefined;
+        
+        const result = conn.checkChallengeBot(notification);
+        
+        assert.deepEqual(result, ({ reject: false }));
+    });
+
+    it('also do not reject game in ranked games', () => {
+
+        const notification = base_challenge({ ranked: true });
+  
+        config.rejectnew = undefined;
+        
+        const result = conn.checkChallengeBot(notification);
+        
+        assert.deepEqual(result, ({ reject: false }));
+    });
+
+    it('do not reject game if rejectnew is not used, and rejectnewmsg is custom', () => {
+
+        const notification = base_challenge({ ranked: false });
+  
+        config.rejectnew = undefined;
+        config.rejectnewmsg = 'Sorry, i am not available now.';
+        
+        const result = conn.checkChallengeBot(notification);
+        
+        assert.deepEqual(result, ({ reject: false }));
+    });
+
+    it('reject all games if rejectnewfile is used and a reject file exists', () => {
+
+        const notification = base_challenge({ ranked: false });
+  
+        // relative path from where fs was required (in connection.js, so root of gtp2ogs)
+        config.rejectnewfile = "./test/rejectnew/rejectnew-file.txt";
+        
+        const result = conn.checkChallengeBot(notification);
+        
+        assert.deepEqual(result, ({ reject: true, msg: 'Currently, this bot is not accepting games, try again later' }));
+    });
+
+    it('reject all games if rejectnewfile is used but a reject file does not exist, and rejectnew msg is default', () => {
+
+        const notification = base_challenge({ ranked: false });
+  
+        // relative path from where fs was required (in connection.js, so root of gtp2ogs)
+        config.rejectnewfile = "./test/rejectnew/rejectnew-file-someotherfilethatdoesnotexist.txt";
+        
+        const result = conn.checkChallengeBot(notification);
+        
+        assert.deepEqual(result, ({ reject: false }));
+    });
+
+    it('reject all games if rejectnewfile is used but a reject file does not exist, and rejectnew msg is custom', () => {
+
+        const notification = base_challenge({ ranked: false });
+  
+        // relative path from where fs was required (in connection.js, so root of gtp2ogs)
+        config.rejectnewfile = "./test/rejectnew/rejectnew-file-someotherfilethatdoesnotexist.txt";
+        config.rejectnewmsg = 'Sorry, i am not available now.';
+        
+        const result = conn.checkChallengeBot(notification);
+        
+        assert.deepEqual(result, ({ reject: false }));
+    });
+   
+  });
+
   describe('Non-square boardsizes', () => {
     it('reject non-square boardsizes if not boardsizes "all"', () => {
 

--- a/test/checkChallenge.test.js
+++ b/test/checkChallenge.test.js
@@ -1,6 +1,7 @@
 // vim: tw=120 softtabstop=4 shiftwidth=4
 
 const assert = require('assert');
+const fs = require('fs');
 const https = require('https');
 const sinon = require('sinon');
 
@@ -293,8 +294,8 @@ describe('Challenges', () => {
       const notification = base_challenge({ ranked: false });
 
       config.rejectnew = true;
-      
-      const result = conn.checkChallengeBot(notification);
+
+      const result = conn.checkChallengeBot(notification, fs);
       
       assert.deepEqual(result, ({ reject: true, msg: 'Currently, this bot is not accepting games, try again later' }));
     });
@@ -306,7 +307,7 @@ describe('Challenges', () => {
   
         config.rejectnew = true;
         
-        const result = conn.checkChallengeBot(notification);
+        const result = conn.checkChallengeBot(notification, fs);
         
         assert.deepEqual(result, ({ reject: true, msg: 'Currently, this bot is not accepting games, try again later' }));
     });
@@ -318,7 +319,7 @@ describe('Challenges', () => {
         config.rejectnew = true;
         config.rejectnewmsg = 'Sorry, i am not available now.';
         
-        const result = conn.checkChallengeBot(notification);
+        const result = conn.checkChallengeBot(notification, fs);
         
         assert.deepEqual(result, ({ reject: true, msg: 'Sorry, i am not available now.' }));
     });
@@ -327,7 +328,7 @@ describe('Challenges', () => {
 
         const notification = base_challenge({ ranked: false });
         
-        const result = conn.checkChallengeBot(notification);
+        const result = conn.checkChallengeBot(notification, fs);
         
         assert.deepEqual(result, ({ reject: false }));
     });
@@ -336,7 +337,7 @@ describe('Challenges', () => {
 
         const notification = base_challenge({ ranked: true });
         
-        const result = conn.checkChallengeBot(notification);
+        const result = conn.checkChallengeBot(notification, fs);
         
         assert.deepEqual(result, ({ reject: false }));
     });
@@ -347,7 +348,7 @@ describe('Challenges', () => {
 
         config.rejectnewmsg = 'Sorry, i am not available now.';
         
-        const result = conn.checkChallengeBot(notification);
+        const result = conn.checkChallengeBot(notification, fs);
         
         assert.deepEqual(result, ({ reject: false }));
     });
@@ -359,7 +360,7 @@ describe('Challenges', () => {
         // relative path from where shell is, so root of gtp2ogs
         config.rejectnewfile = "./test/rejectnew/rejectnew-file.txt";
         
-        const result = conn.checkChallengeBot(notification);
+        const result = conn.checkChallengeBot(notification, fs);
         
         assert.deepEqual(result, ({ reject: true, msg: 'Currently, this bot is not accepting games, try again later' }));
     });
@@ -371,7 +372,7 @@ describe('Challenges', () => {
         // relative path from where shell is, so root of gtp2ogs
         config.rejectnewfile = "./test/rejectnew/rejectnew-file-someotherfilethatdoesnotexist.txt";
         
-        const result = conn.checkChallengeBot(notification);
+        const result = conn.checkChallengeBot(notification, fs);
         
         assert.deepEqual(result, ({ reject: false }));
     });
@@ -384,7 +385,7 @@ describe('Challenges', () => {
         config.rejectnewfile = "./test/rejectnew/rejectnew-file-someotherfilethatdoesnotexist.txt";
         config.rejectnewmsg = 'Sorry, i am not available now.';
         
-        const result = conn.checkChallengeBot(notification);
+        const result = conn.checkChallengeBot(notification, fs);
         
         assert.deepEqual(result, ({ reject: false }));
     });

--- a/test/checkChallenge.test.js
+++ b/test/checkChallenge.test.js
@@ -362,7 +362,7 @@ describe('Challenges', () => {
 
         const notification = base_challenge({ ranked: false });
   
-        // relative path from where fs was required (in connection.js, so root of gtp2ogs)
+        // relative path from where shell is, so root of gtp2ogs)
         config.rejectnewfile = "./test/rejectnew/rejectnew-file.txt";
         
         const result = conn.checkChallengeBot(notification);
@@ -374,7 +374,7 @@ describe('Challenges', () => {
 
         const notification = base_challenge({ ranked: false });
   
-        // relative path from where fs was required (in connection.js, so root of gtp2ogs)
+        // relative path from where shell is, so root of gtp2ogs)
         config.rejectnewfile = "./test/rejectnew/rejectnew-file-someotherfilethatdoesnotexist.txt";
         
         const result = conn.checkChallengeBot(notification);
@@ -386,7 +386,7 @@ describe('Challenges', () => {
 
         const notification = base_challenge({ ranked: false });
   
-        // relative path from where fs was required (in connection.js, so root of gtp2ogs)
+        // relative path from where shell is, so root of gtp2ogs)
         config.rejectnewfile = "./test/rejectnew/rejectnew-file-someotherfilethatdoesnotexist.txt";
         config.rejectnewmsg = 'Sorry, i am not available now.';
         

--- a/test/checkChallenge.test.js
+++ b/test/checkChallenge.test.js
@@ -288,8 +288,6 @@ describe('Challenges', () => {
 
   describe('Rejectnew', () => {
 
-    // rejectnew is ranked-unranked aspecific, so ranked unranked testing is minimal
-
     it('reject all games if rejectnew is used with default rejectnewmsg', () => {
 
       const notification = base_challenge({ ranked: false });
@@ -301,6 +299,7 @@ describe('Challenges', () => {
       assert.deepEqual(result, ({ reject: true, msg: 'Currently, this bot is not accepting games, try again later' }));
     });
 
+    // rejectnew is ranked-unranked aspecific, so ranked unranked testing is minimal
     it('also rejectnew in ranked games', () => {
 
         const notification = base_challenge({ ranked: true });
@@ -327,8 +326,6 @@ describe('Challenges', () => {
     it('do not reject game if rejectnew is not used, and rejectnewmsg is default', () => {
 
         const notification = base_challenge({ ranked: false });
-  
-        config.rejectnew = undefined;
         
         const result = conn.checkChallengeBot(notification);
         
@@ -338,8 +335,6 @@ describe('Challenges', () => {
     it('also do not reject game in ranked games', () => {
 
         const notification = base_challenge({ ranked: true });
-  
-        config.rejectnew = undefined;
         
         const result = conn.checkChallengeBot(notification);
         
@@ -349,8 +344,7 @@ describe('Challenges', () => {
     it('do not reject game if rejectnew is not used, and rejectnewmsg is custom', () => {
 
         const notification = base_challenge({ ranked: false });
-  
-        config.rejectnew = undefined;
+
         config.rejectnewmsg = 'Sorry, i am not available now.';
         
         const result = conn.checkChallengeBot(notification);
@@ -362,7 +356,7 @@ describe('Challenges', () => {
 
         const notification = base_challenge({ ranked: false });
   
-        // relative path from where shell is, so root of gtp2ogs)
+        // relative path from where shell is, so root of gtp2ogs
         config.rejectnewfile = "./test/rejectnew/rejectnew-file.txt";
         
         const result = conn.checkChallengeBot(notification);
@@ -370,11 +364,11 @@ describe('Challenges', () => {
         assert.deepEqual(result, ({ reject: true, msg: 'Currently, this bot is not accepting games, try again later' }));
     });
 
-    it('reject all games if rejectnewfile is used but a reject file does not exist, and rejectnew msg is default', () => {
+    it('accept all games if rejectnewfile is used but a reject file does not exist, and rejectnew msg is default', () => {
 
         const notification = base_challenge({ ranked: false });
   
-        // relative path from where shell is, so root of gtp2ogs)
+        // relative path from where shell is, so root of gtp2ogs
         config.rejectnewfile = "./test/rejectnew/rejectnew-file-someotherfilethatdoesnotexist.txt";
         
         const result = conn.checkChallengeBot(notification);
@@ -382,11 +376,11 @@ describe('Challenges', () => {
         assert.deepEqual(result, ({ reject: false }));
     });
 
-    it('reject all games if rejectnewfile is used but a reject file does not exist, and rejectnew msg is custom', () => {
+    it('accept all games if rejectnewfile is used but a reject file does not exist, and rejectnew msg is custom', () => {
 
         const notification = base_challenge({ ranked: false });
   
-        // relative path from where shell is, so root of gtp2ogs)
+        // relative path from where shell is, so root of gtp2ogs
         config.rejectnewfile = "./test/rejectnew/rejectnew-file-someotherfilethatdoesnotexist.txt";
         config.rejectnewmsg = 'Sorry, i am not available now.';
         

--- a/test/module_loading/assignConfigArguments.js
+++ b/test/module_loading/assignConfigArguments.js
@@ -1,9 +1,13 @@
+const { rootOptionsDefaults } = require('../../constants');
+
 function assignConfigArguments(config) {
     config.DEBUG = true;
     config.apikey = 'deadbeef';
     config.host = 'test';
     config.port = 80;
     config.username = 'testbot';
+
+    config.rejectnewmsg = rootOptionsDefaults.rejectnewmsg;
 
     config.bot_command = ['gtp-program', '--argument'];
 }

--- a/test/rejectnew/rejectnew-file.txt
+++ b/test/rejectnew/rejectnew-file.txt
@@ -1,0 +1,1 @@
+as long as this file exists, rejectnewfile should reject all games in checkChallenge.test.js


### PR DESCRIPTION
removed this chunk from #332 

tested rejectnew and rejectnewfile (with absolute and relative path) to work on beta (didnt test rejectnewmsg but unit testing is implemented in checkChallenge.test.js)

extra testing for this was added in #332 in config.test.js

should be ready to merge after we review this