### PR TITLE
Improved time settings

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -45,7 +45,7 @@ class Bot {
         }
 
         this.proc.stderr.pipe(split2()).on('data', (data) => {
-            if (this.ignore)  return;
+            if (this.ignore) return;
             const errline = data.toString().trim();
             if (errline === "") return;
             this.error(`stderr: ${errline}`);
@@ -61,7 +61,7 @@ class Bot {
 
         let stdout_buffer = "";
         this.proc.stdout.on('data', (data) => {
-            if (this.ignore)  return;
+            if (this.ignore) return;
             stdout_buffer += data.toString();
 
             if (config.json) {
@@ -145,7 +145,7 @@ class Bot {
         }
     }
     log() {
-        const arr = [ `[${this.pid()}]` ];
+        const arr = [`[${this.pid()}]`];
         for (let i = 0; i < arguments.length; ++i) {
             arr.push(arguments[i]);
         }
@@ -153,7 +153,7 @@ class Bot {
         console.log.apply(null, arr);
     }
     error() {
-        const arr = [ `[${this.pid()}]` ];
+        const arr = [`[${this.pid()}]`];
         for (let i = 0; i < arguments.length; ++i) {
             arr.push(arguments[i]);
         }
@@ -161,7 +161,7 @@ class Bot {
         console.error.apply(null, arr);
     }
     verbose() {
-        const arr = [ `[${this.pid()}]` ];
+        const arr = [`[${this.pid()}]`];
         for (let i = 0; i < arguments.length; ++i) {
             arr.push(arguments[i]);
         }
@@ -185,7 +185,7 @@ class Bot {
           
            Japanese byoyomi with one period left could be viewed as a special case 
            of Canadian byoyomi where the number of stones is always = 1
-        */  
+        */
         if (config.noclock) return;
 
         // clock_drift compensates for difference between server and client time, and latency.
@@ -197,98 +197,105 @@ class Bot {
         // offset indicates how long we've had since last move. Ogs only communicates how much
         // time the player had when last move was made.
         if (state.clock.current_player === state.clock.black_player_id) {
-            black_offset = ((this.firstmove===true ? config.startupbuffer : 0) + now - state.clock.last_move) / 1000;
+            black_offset = ((this.firstmove === true ? config.startupbuffer : 0) + now - state.clock.last_move) / 1000;
         } else {
-            white_offset = ((this.firstmove===true ? config.startupbuffer : 0) + now - state.clock.last_move) / 1000;
+            white_offset = ((this.firstmove === true ? config.startupbuffer : 0) + now - state.clock.last_move) / 1000;
         }
 
         if (state.time_control.system === 'byoyomi') {
-            /* GTP spec says time_left should have 0 for stones until main_time has run out.
+            let black_time = state.clock.black_time.thinking_time;
+            let white_time = state.clock.white_time.thinking_time;
+            let black_periods = state.clock.black_time.periods;
+            let white_periods = state.clock.white_time.periods;
+            let black_timeleft = 0;
+            let white_timeleft = 0;
 
-               If the bot connects in the middle of a byoyomi period, it won't know
-               how much time it has left before the period expires.
-               When restarting the bot mid-match during testing, it sometimes lost 
-               on timeout because of this. 
-               To work around it, we can reduce the byoyomi period size by the offset.
-               Not strictly accurate but GTP protocol provides nothing better.
-               Once bot moves again, the next state setup should have this corrected.
-               This problem would happen if a bot were to crash and re-start during a period.
-               This is only an issue if it is our turn, and our main time left is 0.
-            */
             if (this.kgstime) {
-                let black_timeleft = 0;
-                let white_timeleft = 0;
-
-                if (state.clock.black_time.thinking_time > 0) {
-                    black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
+                if (black_time > 0) {
+                    black_timeleft = Math.floor(black_time - black_offset);
                 } else {
-                    black_timeleft = Math.max( Math.floor(state.time_control.period_time - black_offset), 0);
+                    black_timeleft = Math.floor(state.time_control.period_time - black_offset);
                 }
 
-                if (state.clock.white_time.thinking_time > 0) {
-                    white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
+                if (white_time > 0) {
+                    white_timeleft = Math.floor(white_time - white_offset);
                 } else {
-                    white_timeleft = Math.max( Math.floor(state.time_control.period_time - white_offset), 0);
+                    white_timeleft = Math.floor(state.time_control.period_time - white_offset);
                 }
 
-                /* Restarting the bot can make a time left so small the bot makes a 
-                   rushed terrible move.
-                   If we have less than half a period to think and extra periods left,
-                   lets go ahead and use the period up.
-                */
-                if (state.clock.black_time.thinking_time === 0 && state.clock.black_time.periods > 1 && black_timeleft < state.time_control.period_time / 2) {
-                    black_timeleft = Math.max( Math.floor(state.time_control.period_time - black_offset) + state.time_control.period_time, 0 );
-                    state.clock.black_time.periods--;
+                // If we're so slow that time left - offset is negative, we need to roll over to period time.
+                while (black_timeleft < 0 && black_periods > 1) {
+                    black_timeleft += state.clock.black_time.period_time;
+                    if (black_time > 0) {
+                        black_time = 0;
+                    } else {
+                        black_periods--;
+                    }
                 }
-
-                if (state.clock.white_time.thinking_time === 0 && state.clock.white_time.periods > 1 && white_timeleft < state.time_control.period_time / 2) {
-                    white_timeleft = Math.max( Math.floor(state.time_control.period_time - white_offset) + state.time_control.period_time, 0 );
-                    state.clock.white_time.periods--;
+                while (white_timeleft < 0 && white_periods > 1) {
+                    white_timeleft += state.clock.white_time.period_time;
+                    if (white_time > 0) {
+                        white_time = 0;
+                    } else {
+                        white_periods--;
+                    }
                 }
 
                 this.command("kgs-time_settings byoyomi " + state.time_control.main_time + " "
-                    + Math.floor(state.time_control.period_time -
-                        (state.clock.current_player === state.clock.black_player_id ? black_offset : white_offset)
-                    )
+                    + state.time_control.period_time
                     + " " + state.time_control.periods);
-
-                /* Turns out in Japanese byoyomi mode, for Leela and pacci,
-                   they expect time left in the current byoyomi period on time_left.
-                */
-
-               this.command("time_left black " + black_timeleft + " " + (state.clock.black_time.thinking_time > 0 ? "0" : state.clock.black_time.periods));
-               this.command("time_left white " + white_timeleft + " " + (state.clock.white_time.thinking_time > 0 ? "0" : state.clock.white_time.periods));
+                this.command("time_left black " + Math.max(black_timeleft, 0) + " " + (black_time > 0 ? "0" : black_periods));
+                this.command("time_left white " + Math.max(white_timeleft, 0) + " " + (white_time > 0 ? "0" : white_periods));
             } else {
-                /* OGS enforces the number of periods is always 1 or greater.
+                /* Gtp does not support japanese byoyom. We fake it as Canadian byoyomi.
                    Let's pretend the final period is a Canadian Byoyomi of 1 stone.
                    This lets the bot know it can use the full period per move,
                    not try to fit the rest of the game into the time left.
                 */
-                let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time
-                    - black_offset + (state.clock.black_time.periods - 1) * state.time_control.period_time), 0);
-                let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time
-                    - white_offset + (state.clock.white_time.periods - 1) * state.time_control.period_time), 0);
+                // add all periods to the main time.
+                // If we're already in overtime, exclude the current period.
+                if (black_time > 0) {
+                    black_timeleft = Math.floor(black_time - black_offset) + state.clock.black_time.period_time * black_periods;
+                } else {
+                    black_timeleft = Math.floor(state.time_control.period_time - black_offset) + state.clock.black_time.period_time * (black_periods - 1);
+                }
+                if (white_time > 0) {
+                    white_timeleft = Math.floor(white_time - white_offset) + state.clock.black_time.period_time * black_periods;
+                } else {
+                    white_timeleft = Math.floor(state.time_control.period_time - white_offset) + state.clock.black_time.period_time * (black_periods - 1);
+                }
 
                 this.command("time_settings " + (state.time_control.main_time + (state.time_control.periods - 1) * state.time_control.period_time) + " "
-                    + Math.floor(state.time_control.period_time -
-                        (state.clock.current_player === state.clock.black_player_id
-                            ? (black_timeleft > 0 ? 0 : black_offset) : (white_timeleft > 0 ? 0 : white_offset)
-                        )
-                    )
+                    + state.time_control.period_time
                     + " 1");
-                /* Since we're faking byoyomi using Canadian, time_left actually
-                   does mean the time left to play our 1 stone.
-                */
-                this.command("time_left black " + (black_timeleft > 0 ? black_timeleft + " 0"
-                    : Math.floor(state.time_control.period_time - black_offset) + " 1") );
-                this.command("time_left white " + (white_timeleft > 0 ? white_timeleft + " 0"
-                    : Math.floor(state.time_control.period_time - white_offset) + " 1") );
+                // If we're in the last period, tell the bot. Otherwise pretend we're in main time.
+                if (black_timeleft <= state.clock.black_time.period_time) {
+                    this.command("time_left black " + Math.max(black_timeleft, 0) + " 1");
+                } else {
+                    this.command("time_left black " + (black_timeleft - state.clock.black_time.period_time) + " 0");
+                }
+                if (white_timeleft <= state.clock.white_time.period_time) {
+                    this.command("time_left white " + Math.max(white_timeleft, 0) + " 1");
+                } else {
+                    this.command("time_left white " + (white_timeleft - state.clock.white_time.period_time) + " 0");
+                }
             }
         } else if (state.time_control.system === 'canadian') {
             /* Canadian Byoyomi is the only time controls GTP v2 officially supports.
-            */ 
-            let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
-            let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
+            */
+            let black_timeleft = Math.floor(state.clock.black_time.thinking_time - black_offset);
+            let white_timeleft = Math.floor(state.clock.white_time.thinking_time - white_offset);
+            let black_stones = 0;
+            let white_stones = 0;
+
+            if (black_timeleft <= 0) {
+                black_stones = state.clock.black_time.moves_left;
+                black_timeleft += state.clock.black_time.block_time;
+            }
+            if (white_timeleft <= 0) {
+                white_stones = state.clock.white_time.moves_left;
+                white_timeleft += state.clock.white_time.block_time;
+            }
 
             if (this.kgstime) {
                 this.command("kgs-time_settings canadian " + state.time_control.main_time + " "
@@ -298,18 +305,18 @@ class Bot {
                     + state.time_control.period_time + " " + state.time_control.stones_per_period);
             }
 
-            this.command("time_left black " + (black_timeleft > 0 ? black_timeleft + " 0"
-                : Math.floor(state.clock.black_time.block_time - black_offset) + " " + state.clock.black_time.moves_left));
-            this.command("time_left white " + (white_timeleft > 0 ? white_timeleft + " 0"
-                : Math.floor(state.clock.white_time.block_time - white_offset) + " " + state.clock.white_time.moves_left));
+            this.command("time_left black " + Math.max(black_timeleft, 0) + " " + black_stones);
+            this.command("time_left white " + Math.max(white_timeleft, 0) + " " + white_stones);
         } else if (state.time_control.system === 'fischer') {
             /* Not supported by kgs-time_settings and I assume most bots.
                A better way than absolute is to handle this with
                a fake Canadian byoyomi. This should let the bot know
                a good approximation of how to handle the time remaining.
             */
-            let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
-            let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
+            let black_timeleft = Math.floor(state.clock.black_time.thinking_time - black_offset) - state.time_control.time_increment;
+            let white_timeleft = Math.floor(state.clock.white_time.thinking_time - white_offset) - state.time_control.time_increment;
+            let black_periods = 0;
+            let white_periods = 0;
 
             if (this.kgstime) {
                 this.command("kgs-time_settings canadian " + (state.time_control.initial_time - state.time_control.time_increment)
@@ -319,39 +326,38 @@ class Bot {
                     + " " + state.time_control.time_increment + " 1");
             }
 
+            if (black_timeleft <= 0) {
+                black_periods = 1;
+                black_timeleft += state.time_control.time_increment;
+            }
+            if (white_timeleft <= 0) {
+                white_periods = 1;
+                white_timeleft += state.time_control.time_increment;
+            }
+
             /* Always tell the bot we are in main time ('0') so it doesn't try
                to think all of timeleft per move.
                But subtract the increment time above to avoid timeouts.
             */
-            this.command("time_left black " + black_timeleft + " 0");
-            this.command("time_left white " + white_timeleft + " 0");
+            this.command("time_left black " + Math.max(black_timeleft, 0) + " " + black_periods);
+            this.command("time_left white " + Math.max(white_timeleft, 0) + " " + white_periods);
         } else if (state.time_control.system === 'simple') {
             /* Simple could also be viewed as a Canadian byomoyi that starts
                immediately with # of stones = 1
             */
+            let black_timeleft = Math.floor(state.clock.black_time - black_offset);
+            let white_timeleft = Math.floor(state.clock.white_time - white_offset);
+
             this.command("time_settings 0 " + state.time_control.per_move + " 1");
-
-            if (state.clock.black_time)
-            {
-                let black_timeleft = Math.max( Math.floor((state.clock.black_time - now)/1000 - black_offset), 0);
-                this.command("time_left black " + black_timeleft + " 1");
-                this.command("time_left white 1 1");
-            } else {
-                let white_timeleft = Math.max( Math.floor((state.clock.white_time - now)/1000 - white_offset), 0);
-                this.command("time_left black 1 1");
-                this.command("time_left white " + white_timeleft + " 1");
-            }
+            this.command("time_left black " + Math.max(black_timeleft, 0) + " 1");
+            this.command("time_left white " + Math.max(white_timeleft, 0) + " 1");
         } else if (state.time_control.system === 'absolute') {
-            let black_timeleft = Math.max( Math.floor(state.clock.black_time.thinking_time - black_offset), 0);
-            let white_timeleft = Math.max( Math.floor(state.clock.white_time.thinking_time - white_offset), 0);
+            let black_timeleft = Math.floor(state.clock.black_time.thinking_time - black_offset);
+            let white_timeleft = Math.floor(state.clock.white_time.thinking_time - white_offset);
 
-            if (this.kgstime) {
-                this.command("kgs-time_settings absolute " + state.time_control.total_time);
-            } else {
-                this.command("time_settings " + state.time_control.total_time + " 0 0");
-            }
-            this.command("time_left black " + black_timeleft + " 0");
-            this.command("time_left white " + white_timeleft + " 0");
+            this.command("time_settings " + state.time_control.total_time + " 0 0");
+            this.command("time_left black " + Math.max(black_timeleft, 0) + " 0");
+            this.command("time_left white " + Math.max(white_timeleft, 0) + " 0");
         }
         /*  OGS doesn't actually send 'none' time control type
             else if (state.time_control.system === 'none') {
@@ -365,7 +371,7 @@ class Bot {
             }
         */
     }
-    
+
     loadState(state, cb, eb) {
         if (this.dead) {
             if (config.DEBUG) { this.log("Attempting to load dead bot") }
@@ -391,12 +397,12 @@ class Bot {
 
     loadState2(state, cb, eb) {
         if (state.width === state.height) {
-            this.command(`boardsize ${state.width}`, () => {}, eb);
+            this.command(`boardsize ${state.width}`, () => { }, eb);
         } else {
-            this.command(`boardsize ${state.width} ${state.height}`, () => {}, eb);
+            this.command(`boardsize ${state.width} ${state.height}`, () => { }, eb);
         }
-        this.command("clear_board", () => {}, eb);
-        this.command(`komi ${state.komi}`, () => {}, eb);
+        this.command("clear_board", () => { }, eb);
+        this.command(`komi ${state.komi}`, () => { }, eb);
         //this.log(state);
 
         //this.loadClock(state);
@@ -408,9 +414,9 @@ class Bot {
             have_initial_state = (black.length || white.length);
 
             for (let i = 0; i < black.length; ++i)
-                this.command(`play black ${move2gtpvertex(black[i], state.width, state.height)}`, () => {}, eb);
+                this.command(`play black ${move2gtpvertex(black[i], state.width, state.height)}`, () => { }, eb);
             for (let i = 0; i < white.length; ++i)
-                this.command(`play white ${move2gtpvertex(white[i], state.width, state.height)}`, () => {}, eb);
+                this.command(`play white ${move2gtpvertex(white[i], state.width, state.height)}`, () => { }, eb);
         }
 
         // Replay moves made
@@ -499,7 +505,7 @@ class Bot {
         this.firstmove = false;
 
         this.command(cmd, (line) => {
-            line = typeof(line) === "string" ? line.toLowerCase() : null;
+            line = typeof (line) === "string" ? line.toLowerCase() : null;
             const parts = line.split(/ +/);
             const moves = [];
 
@@ -519,7 +525,7 @@ class Bot {
                         resign = true;
                     }
                 }
-                moves.push({'x': x, 'y': y, 'text': move, 'resign': resign, 'pass': pass});
+                moves.push({ 'x': x, 'y': y, 'text': move, 'resign': resign, 'pass': pass });
             }
 
             cb(moves);
@@ -544,7 +550,7 @@ class Bot {
             }, 5000);
         }
     }
-    sendMove(move, width, height, color){
+    sendMove(move, width, height, color) {
         if (config.DEBUG) this.log("Calling sendMove with", move2gtpvertex(move, width, height));
         this.command(`play ${color} ${move2gtpvertex(move, width, height)}`);
     }

--- a/bot.js
+++ b/bot.js
@@ -173,18 +173,18 @@ class Bot {
            http://www.lysator.liu.se/~gunnar/gtp/gtp2-spec-draft2/gtp2-spec.html#sec:time-handling
            http://www.weddslist.com/kgs/how/kgsGtp.html
 
-           GTP v2 only supports Canadian byoyomi, no timer (see spec above), 
+           GTP v2 only supports Canadian Byoyomi, no timer (see spec above), 
            and absolute (period time zero).
           
-           kgs-time_settings adds support for Japanese byoyomi.
+           kgs-time_settings adds support for Japanese Byoyomi.
           
            The kgsGtp interface (http://www.weddslist.com/kgs/how/kgsGtp.html)
            converts byoyomi to absolute time for bots that don't support 
            kgs-time_settings by using main_time plus periods * period_time.
            But then the bot would view that as the total time left for entire rest of game...
           
-           Japanese byoyomi with one period left could be viewed as a special case 
-           of Canadian byoyomi where the number of stones is always = 1
+           Japanese Byoyomi with one period left could be viewed as a special case 
+           of Canadian Byoyomi where the number of stones is always = 1
         */
         if (config.noclock) return;
 
@@ -245,7 +245,7 @@ class Bot {
                 this.command(`time_left black ${Math.floor(Math.max(black_timeleft, 0))} ${black_time > 0 ? "0" : black_periods}`);
                 this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} ${white_time > 0 ? "0" : white_periods}`);
             } else {
-                /* Gtp does not support japanese byoyom. We fake it as Canadian byoyomi.
+                /* Gtp does not support Japanese Byoyomi. We fake it as Canadian Byoyomi.
                    Let's pretend the final period is a Canadian Byoyomi of 1 stone.
                    This lets the bot know it can use the full period per move,
                    not try to fit the rest of the game into the time left.
@@ -311,7 +311,7 @@ class Bot {
             } else {
                 /* Not supported by kgs-time_settings and I assume most bots.
                    A better way than absolute is to handle this with
-                   a fake Canadian byoyomi. This should let the bot know
+                   a fake Canadian Byoyomi. This should let the bot know
                    a good approximation of how to handle the time remaining.
                 */
                let black_timeleft = state.clock.black_time.thinking_time - black_offset - state.time_control.time_increment;
@@ -342,7 +342,7 @@ class Bot {
                this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} ${white_periods}`);
             }
         } else if (state.time_control.system === 'simple') {
-            /* Simple could also be viewed as a Canadian byomoyi that starts
+            /* Simple could also be viewed as a Canadian Byoyomi that starts
                immediately with # of stones = 1
             */
 

--- a/bot.js
+++ b/bot.js
@@ -178,8 +178,6 @@ class Bot {
           
            kgs-time_settings adds support for Japanese byoyomi.
           
-           TODO: Use known_commands to check for kgs-time_settings support automatically.
-          
            The kgsGtp interface (http://www.weddslist.com/kgs/how/kgsGtp.html)
            converts byoyomi to absolute time for bots that don't support 
            kgs-time_settings by using main_time plus periods * period_time.
@@ -190,12 +188,14 @@ class Bot {
         */  
         if (config.noclock) return;
 
-        //let now = state.clock.now ? state.clock.now : (Date.now() - this.conn.clock_drift);
+        // clock_drift compensates for difference between server and client time, and latency.
         let now = Date.now() - this.conn.clock_drift;
 
         let black_offset = 0;
         let white_offset = 0;
 
+        // offset indicates how long we've had since last move. Ogs only communicates how much
+        // time the player had when last move was made.
         if (state.clock.current_player === state.clock.black_player_id) {
             black_offset = ((this.firstmove===true ? config.startupbuffer : 0) + now - state.clock.last_move) / 1000;
         } else {
@@ -256,8 +256,8 @@ class Bot {
                    they expect time left in the current byoyomi period on time_left.
                 */
 
-                this.command("time_left black " + black_timeleft + " " + (state.clock.black_time.thinking_time > 0 ? "0" : state.clock.black_time.periods));
-                this.command("time_left white " + white_timeleft + " " + (state.clock.white_time.thinking_time > 0 ? "0" : state.clock.white_time.periods));
+               this.command("time_left black " + black_timeleft + " " + (state.clock.black_time.thinking_time > 0 ? "0" : state.clock.black_time.periods));
+               this.command("time_left white " + white_timeleft + " " + (state.clock.white_time.thinking_time > 0 ? "0" : state.clock.white_time.periods));
             } else {
                 /* OGS enforces the number of periods is always 1 or greater.
                    Let's pretend the final period is a Canadian Byoyomi of 1 stone.

--- a/bot.js
+++ b/bot.js
@@ -345,15 +345,19 @@ class Bot {
             /* Simple could also be viewed as a Canadian byomoyi that starts
                immediately with # of stones = 1
             */
-            let black_timeleft = state.clock.black_time - black_offset;
-            let white_timeleft = state.clock.white_time - white_offset;
+
+            // for some reason ogs sends a timestamp (equal to state.clock.last_move) instead of our time.
+            // Luckely we can use state.time_control.per_move since simple time is always in overtime.
+            let black_timeleft = state.time_control.per_move - black_offset;
+            let white_timeleft = state.time_control.per_move - white_offset;
 
             this.command("time_settings 0 " + state.time_control.per_move + " 1");
+
             this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " 1");
             this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " 1");
         } else if (state.time_control.system === 'absolute') {
             let black_timeleft = state.clock.black_time.thinking_time - black_offset;
-            let white_timeleft =state.clock.white_time.thinking_time - white_offset;
+            let white_timeleft = state.clock.white_time.thinking_time - white_offset;
 
             this.command("time_settings " + state.time_control.total_time + " 0 0");
             this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " 0");

--- a/bot.js
+++ b/bot.js
@@ -241,11 +241,9 @@ class Bot {
                     }
                 }
 
-                this.command("kgs-time_settings byoyomi " + state.time_control.main_time + " "
-                    + state.time_control.period_time
-                    + " " + state.time_control.periods);
-                this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " " + (black_time > 0 ? "0" : black_periods));
-                this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " " + (white_time > 0 ? "0" : white_periods));
+                this.command(`kgs-time_settings byoyomi ${state.time_control.main_time} ${state.time_control.period_time} ${state.time_control.periods}`);
+                this.command(`time_left black ${Math.floor(Math.max(black_timeleft, 0))} ${black_time > 0 ? "0" : black_periods}`);
+                this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} ${white_time > 0 ? "0" : white_periods}`);
             } else {
                 /* Gtp does not support japanese byoyom. We fake it as Canadian byoyomi.
                    Let's pretend the final period is a Canadian Byoyomi of 1 stone.
@@ -265,19 +263,17 @@ class Bot {
                     white_timeleft = state.time_control.period_time - white_offset + state.clock.black_time.period_time * (black_periods - 1);
                 }
 
-                this.command("time_settings " + (state.time_control.main_time + (state.time_control.periods - 1) * state.time_control.period_time) + " "
-                    + state.time_control.period_time
-                    + " 1");
+                this.command(`time_settings ${state.time_control.main_time + (state.time_control.periods - 1) * state.time_control.period_time} ${state.time_control.period_time} 1`);
                 // If we're in the last period, tell the bot. Otherwise pretend we're in main time.
                 if (black_timeleft <= state.clock.black_time.period_time) {
-                    this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " 1");
+                    this.command(`time_left black ${Math.floor(Math.max(black_timeleft, 0))} 1`);
                 } else {
-                    this.command("time_left black " + Math.floor(black_timeleft - state.clock.black_time.period_time) + " 0");
+                    this.command(`time_left black ${Math.floor(black_timeleft - state.clock.black_time.period_time)} 0`);
                 }
                 if (white_timeleft <= state.clock.white_time.period_time) {
-                    this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " 1");
+                    this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} 1`);
                 } else {
-                    this.command("time_left white " + Math.floor(white_timeleft - state.clock.white_time.period_time) + " 0");
+                    this.command(`time_left white ${Math.floor(white_timeleft - state.clock.white_time.period_time)} 0`);
                 }
             }
         } else if (state.time_control.system === 'canadian') {
@@ -298,49 +294,53 @@ class Bot {
             }
 
             if (this.kgstime) {
-                this.command("kgs-time_settings canadian " + state.time_control.main_time + " "
-                    + state.time_control.period_time + " " + state.time_control.stones_per_period);
+                this.command(`kgs-time_settings canadian ${state.time_control.main_time} ${state.time_control.period_time} ${state.time_control.stones_per_period}`);
             } else {
-                this.command("time_settings " + state.time_control.main_time + " "
-                    + state.time_control.period_time + " " + state.time_control.stones_per_period);
+                this.command(`time_settings ${state.time_control.main_time} ${state.time_control.period_time} ${state.time_control.stones_per_period}`);
             }
 
-            this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " " + black_stones);
-            this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " " + white_stones);
+            this.command(`time_left black ${Math.floor(Math.max(black_timeleft, 0))} ${black_stones}`);
+            this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} ${white_stones}`);
         } else if (state.time_control.system === 'fischer') {
-            /* Not supported by kgs-time_settings and I assume most bots.
-               A better way than absolute is to handle this with
-               a fake Canadian byoyomi. This should let the bot know
-               a good approximation of how to handle the time remaining.
-            */
-            let black_timeleft = state.clock.black_time.thinking_time - black_offset - state.time_control.time_increment;
-            let white_timeleft = state.clock.white_time.thinking_time - white_offset - state.time_control.time_increment;
-            let black_periods = 0;
-            let white_periods = 0;
-
-            if (this.kgstime) {
-                this.command("kgs-time_settings canadian " + (state.time_control.initial_time - state.time_control.time_increment)
-                    + " " + state.time_control.time_increment + " 1");
+            if (this.katafischer) {
+                let black_timeleft = state.clock.black_time.thinking_time - black_offset;
+                let white_timeleft = state.clock.white_time.thinking_time - white_offset;
+                this.command(`kata-time_settings fischer-capped ${state.time_control.initial_time} ${state.time_control.time_increment} ${state.time_control.max_time} -1`);
+                this.command(`time_left black ${Math.floor(Math.max(black_timeleft, 0))} 0`);
+                this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} 0`);
             } else {
-                this.command("time_settings " + (state.time_control.initial_time - state.time_control.time_increment)
-                    + " " + state.time_control.time_increment + " 1");
-            }
+                /* Not supported by kgs-time_settings and I assume most bots.
+                   A better way than absolute is to handle this with
+                   a fake Canadian byoyomi. This should let the bot know
+                   a good approximation of how to handle the time remaining.
+                */
+               let black_timeleft = state.clock.black_time.thinking_time - black_offset - state.time_control.time_increment;
+               let white_timeleft = state.clock.white_time.thinking_time - white_offset - state.time_control.time_increment;
+               let black_periods = 0;
+               let white_periods = 0;
 
-            if (black_timeleft <= 0) {
-                black_periods = 1;
-                black_timeleft += state.time_control.time_increment;
-            }
-            if (white_timeleft <= 0) {
-                white_periods = 1;
-                white_timeleft += state.time_control.time_increment;
-            }
+               if (this.kgstime) {
+                   this.command(`kgs-time_settings canadian ${state.time_control.initial_time - state.time_control.time_increment} ${state.time_control.time_increment} 1`);
+               } else {
+                   this.command(`time_settings ${state.time_control.initial_time - state.time_control.time_increment} ${state.time_control.time_increment} 1`);
+               }
 
-            /* Always tell the bot we are in main time ('0') so it doesn't try
-               to think all of timeleft per move.
-               But subtract the increment time above to avoid timeouts.
-            */
-            this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " " + black_periods);
-            this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " " + white_periods);
+               if (black_timeleft <= 0) {
+                   black_periods = 1;
+                   black_timeleft += state.time_control.time_increment;
+               }
+               if (white_timeleft <= 0) {
+                   white_periods = 1;
+                   white_timeleft += state.time_control.time_increment;
+               }
+
+               /* Always tell the bot we are in main time ('0') so it doesn't try
+                  to think all of timeleft per move.
+                  But subtract the increment time above to avoid timeouts.
+               */
+               this.command(`time_left black ${Math.floor(Math.max(black_timeleft, 0))} ${black_periods}`);
+               this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} ${white_periods}`);
+            }
         } else if (state.time_control.system === 'simple') {
             /* Simple could also be viewed as a Canadian byomoyi that starts
                immediately with # of stones = 1
@@ -351,17 +351,17 @@ class Bot {
             let black_timeleft = state.time_control.per_move - black_offset;
             let white_timeleft = state.time_control.per_move - white_offset;
 
-            this.command("time_settings 0 " + state.time_control.per_move + " 1");
+            this.command(`time_settings 0 ${state.time_control.per_move} 1`);
 
-            this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " 1");
-            this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " 1");
+            this.command(`time_left black ${Math.floor(Math.max(black_timeleft, 0))} 1`);
+            this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} 1`);
         } else if (state.time_control.system === 'absolute') {
             let black_timeleft = state.clock.black_time.thinking_time - black_offset;
             let white_timeleft = state.clock.white_time.thinking_time - white_offset;
 
-            this.command("time_settings " + state.time_control.total_time + " 0 0");
-            this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " 0");
-            this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " 0");
+            this.command(`time_settings ${state.time_control.total_time} 0 0`);
+            this.command(`time_left black ${Math.floor(Math.max(black_timeleft, 0))} 0`);
+            this.command(`time_left white ${Math.floor(Math.max(white_timeleft, 0))} 0`);
         }
         /*  OGS doesn't actually send 'none' time control type
             else if (state.time_control.system === 'none') {
@@ -389,7 +389,7 @@ class Bot {
             this.katatime = commands.includes("kata-list_time_settings");
             if (this.katatime) {
                 this.command("kata-list_time_settings", (kataTimeSettings) => {
-                    this.katafischer = kataTimeSettings.includes("fischer")
+                    this.katafischer = kataTimeSettings.includes("fischer-capped")
                     this.loadState2(state, cb, eb);
                 }, eb);
             } else {

--- a/bot.js
+++ b/bot.js
@@ -212,15 +212,15 @@ class Bot {
 
             if (this.kgstime) {
                 if (black_time > 0) {
-                    black_timeleft = Math.floor(black_time - black_offset);
+                    black_timeleft = black_time - black_offset;
                 } else {
-                    black_timeleft = Math.floor(state.time_control.period_time - black_offset);
+                    black_timeleft = state.time_control.period_time - black_offset;
                 }
 
                 if (white_time > 0) {
-                    white_timeleft = Math.floor(white_time - white_offset);
+                    white_timeleft = white_time - white_offset;
                 } else {
-                    white_timeleft = Math.floor(state.time_control.period_time - white_offset);
+                    white_timeleft = state.time_control.period_time - white_offset;
                 }
 
                 // If we're so slow that time left - offset is negative, we need to roll over to period time.
@@ -244,8 +244,8 @@ class Bot {
                 this.command("kgs-time_settings byoyomi " + state.time_control.main_time + " "
                     + state.time_control.period_time
                     + " " + state.time_control.periods);
-                this.command("time_left black " + Math.max(black_timeleft, 0) + " " + (black_time > 0 ? "0" : black_periods));
-                this.command("time_left white " + Math.max(white_timeleft, 0) + " " + (white_time > 0 ? "0" : white_periods));
+                this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " " + (black_time > 0 ? "0" : black_periods));
+                this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " " + (white_time > 0 ? "0" : white_periods));
             } else {
                 /* Gtp does not support japanese byoyom. We fake it as Canadian byoyomi.
                    Let's pretend the final period is a Canadian Byoyomi of 1 stone.
@@ -255,14 +255,14 @@ class Bot {
                 // add all periods to the main time.
                 // If we're already in overtime, exclude the current period.
                 if (black_time > 0) {
-                    black_timeleft = Math.floor(black_time - black_offset) + state.clock.black_time.period_time * black_periods;
+                    black_timeleft = black_time - black_offset + state.clock.black_time.period_time * black_periods;
                 } else {
-                    black_timeleft = Math.floor(state.time_control.period_time - black_offset) + state.clock.black_time.period_time * (black_periods - 1);
+                    black_timeleft = state.time_control.period_time - black_offset + state.clock.black_time.period_time * (black_periods - 1);
                 }
                 if (white_time > 0) {
-                    white_timeleft = Math.floor(white_time - white_offset) + state.clock.black_time.period_time * black_periods;
+                    white_timeleft = white_time - white_offset + state.clock.black_time.period_time * black_periods;
                 } else {
-                    white_timeleft = Math.floor(state.time_control.period_time - white_offset) + state.clock.black_time.period_time * (black_periods - 1);
+                    white_timeleft = state.time_control.period_time - white_offset + state.clock.black_time.period_time * (black_periods - 1);
                 }
 
                 this.command("time_settings " + (state.time_control.main_time + (state.time_control.periods - 1) * state.time_control.period_time) + " "
@@ -270,21 +270,21 @@ class Bot {
                     + " 1");
                 // If we're in the last period, tell the bot. Otherwise pretend we're in main time.
                 if (black_timeleft <= state.clock.black_time.period_time) {
-                    this.command("time_left black " + Math.max(black_timeleft, 0) + " 1");
+                    this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " 1");
                 } else {
-                    this.command("time_left black " + (black_timeleft - state.clock.black_time.period_time) + " 0");
+                    this.command("time_left black " + Math.floor(black_timeleft - state.clock.black_time.period_time) + " 0");
                 }
                 if (white_timeleft <= state.clock.white_time.period_time) {
-                    this.command("time_left white " + Math.max(white_timeleft, 0) + " 1");
+                    this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " 1");
                 } else {
-                    this.command("time_left white " + (white_timeleft - state.clock.white_time.period_time) + " 0");
+                    this.command("time_left white " + Math.floor(white_timeleft - state.clock.white_time.period_time) + " 0");
                 }
             }
         } else if (state.time_control.system === 'canadian') {
             /* Canadian Byoyomi is the only time controls GTP v2 officially supports.
             */
-            let black_timeleft = Math.floor(state.clock.black_time.thinking_time - black_offset);
-            let white_timeleft = Math.floor(state.clock.white_time.thinking_time - white_offset);
+            let black_timeleft = state.clock.black_time.thinking_time - black_offset;
+            let white_timeleft = state.clock.white_time.thinking_time - white_offset;
             let black_stones = 0;
             let white_stones = 0;
 
@@ -305,16 +305,16 @@ class Bot {
                     + state.time_control.period_time + " " + state.time_control.stones_per_period);
             }
 
-            this.command("time_left black " + Math.max(black_timeleft, 0) + " " + black_stones);
-            this.command("time_left white " + Math.max(white_timeleft, 0) + " " + white_stones);
+            this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " " + black_stones);
+            this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " " + white_stones);
         } else if (state.time_control.system === 'fischer') {
             /* Not supported by kgs-time_settings and I assume most bots.
                A better way than absolute is to handle this with
                a fake Canadian byoyomi. This should let the bot know
                a good approximation of how to handle the time remaining.
             */
-            let black_timeleft = Math.floor(state.clock.black_time.thinking_time - black_offset) - state.time_control.time_increment;
-            let white_timeleft = Math.floor(state.clock.white_time.thinking_time - white_offset) - state.time_control.time_increment;
+            let black_timeleft = state.clock.black_time.thinking_time - black_offset - state.time_control.time_increment;
+            let white_timeleft = state.clock.white_time.thinking_time - white_offset - state.time_control.time_increment;
             let black_periods = 0;
             let white_periods = 0;
 
@@ -339,25 +339,25 @@ class Bot {
                to think all of timeleft per move.
                But subtract the increment time above to avoid timeouts.
             */
-            this.command("time_left black " + Math.max(black_timeleft, 0) + " " + black_periods);
-            this.command("time_left white " + Math.max(white_timeleft, 0) + " " + white_periods);
+            this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " " + black_periods);
+            this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " " + white_periods);
         } else if (state.time_control.system === 'simple') {
             /* Simple could also be viewed as a Canadian byomoyi that starts
                immediately with # of stones = 1
             */
-            let black_timeleft = Math.floor(state.clock.black_time - black_offset);
-            let white_timeleft = Math.floor(state.clock.white_time - white_offset);
+            let black_timeleft = state.clock.black_time - black_offset;
+            let white_timeleft = state.clock.white_time - white_offset;
 
             this.command("time_settings 0 " + state.time_control.per_move + " 1");
-            this.command("time_left black " + Math.max(black_timeleft, 0) + " 1");
-            this.command("time_left white " + Math.max(white_timeleft, 0) + " 1");
+            this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " 1");
+            this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " 1");
         } else if (state.time_control.system === 'absolute') {
-            let black_timeleft = Math.floor(state.clock.black_time.thinking_time - black_offset);
-            let white_timeleft = Math.floor(state.clock.white_time.thinking_time - white_offset);
+            let black_timeleft = state.clock.black_time.thinking_time - black_offset;
+            let white_timeleft =state.clock.white_time.thinking_time - white_offset;
 
             this.command("time_settings " + state.time_control.total_time + " 0 0");
-            this.command("time_left black " + Math.max(black_timeleft, 0) + " 0");
-            this.command("time_left white " + Math.max(white_timeleft, 0) + " 0");
+            this.command("time_left black " + Math.floor(Math.max(black_timeleft, 0)) + " 0");
+            this.command("time_left white " + Math.floor(Math.max(white_timeleft, 0)) + " 0");
         }
         /*  OGS doesn't actually send 'none' time control type
             else if (state.time_control.system === 'none') {

--- a/docs/OPTIONS-LIST.md
+++ b/docs/OPTIONS-LIST.md
@@ -237,10 +237,6 @@ available on first move (if set)
 
 `--timeout` Disconnect from a game after this many seconds (if set)
 
-### kgstime
-
-`--kgstime`  Set this if bot understands the kgs-time_settings command
-
 ### showboard
 
 `--showboard`  Set this if bot understands the showboard

--- a/game.js
+++ b/game.js
@@ -280,7 +280,7 @@ class Game {
         if (this.bot) {
             cb();
             return;
-        };
+        }
 
         if (this.bot_failures >= 5) {
             // This bot keeps on failing, give up on the game.

--- a/game.js
+++ b/game.js
@@ -153,7 +153,7 @@ class Game {
                     if (config.DEBUG) this.log(noPauseMg);
                     this.resumeGame();
                 }
-            } 
+            }
 
             //this.log("Clock: ", JSON.stringify(clock));
             if (this.state) {
@@ -222,7 +222,7 @@ class Game {
                     // If we are white, we wait for opponent to make extra moves.
                     if (this.bot) this.bot.sendMove(decodeMoves(move.move, this.state.width, this.state.height)[0], this.state.width, this.state.height, this.my_color === "black" ? "white" : "black");
                     if (config.DEBUG) this.log("Waiting for opponent to finish", this.state.handicap - this.state.moves.length, "more handicap moves");
-                    if (this.state.moves.length ===1) { // remind once, avoid spamming the reminder
+                    if (this.state.moves.length === 1) { // remind once, avoid spamming the reminder
                         this.sendChat("Waiting for opponent to place all handicap stones"); // reminding human player in ingame chat
                     }
                 }
@@ -250,7 +250,7 @@ class Game {
             'game_id': game_id
         }));
 
-        this.connect_timeout = setTimeout(()=>{
+        this.connect_timeout = setTimeout(() => {
             if (!this.state) {
                 this.log("No gamedata after 1s, reqesting again");
                 this.scheduleRetry();
@@ -277,7 +277,10 @@ class Game {
             this.ensureBotKilled();
         }
 
-        if (this.bot) return true;
+        if (this.bot) {
+            cb();
+            return;
+        };
 
         if (this.bot_failures >= 5) {
             // This bot keeps on failing, give up on the game.
@@ -327,7 +330,7 @@ class Game {
 
         let failed = false;
         const botError = (e) => {
-            if (failed)  return;
+            if (failed) return;
 
             failed = true;
             doneProcessing();
@@ -341,7 +344,7 @@ class Game {
 
         this.ensureBotStarted(() => this.getBotMoves2(cmd, cb, doneProcessing, botError), botError);
     }
-    
+
     getBotMoves2(cmd, cb, doneProcessing, botError) {
         if (config.DEBUG) this.bot.log("Generating move for game", this.game_id);
         this.log(cmd);
@@ -412,7 +415,7 @@ class Game {
             this.state.moves.length < this.state.handicap);
 
         if (!doing_handicap) {  // Regular genmove ...
-            const sendTheMove = (moves) => {  this.uploadMove(moves[0]);  };
+            const sendTheMove = (moves) => { this.uploadMove(moves[0]); };
             this.getBotMoves(`genmove ${this.my_color}`, sendTheMove, this.scheduleRetry);
             return;
         }
@@ -426,7 +429,7 @@ class Game {
         const warnAndResign = (msg) => {
             this.log(msg);
             this.ensureBotKilled();
-            this.uploadMove({'resign': true});
+            this.uploadMove({ 'resign': true });
         }
 
         // Get handicap stones from bot and return first one.
@@ -472,19 +475,18 @@ class Game {
     }
     getRes(result) {
         const m = this.state.outcome.match(/(.*) points/);
-        if (m)  return m[1];
+        if (m) return m[1];
 
-        if (result === 'Resignation')  return 'R';
+        if (result === 'Resignation') return 'R';
         if (result === 'Cancellation') return 'Can';
-        if (result === 'Timeout')      return 'Time';
+        if (result === 'Timeout') return 'Time';
     }
-    gameOver()
-    {
+    gameOver() {
         if (config.farewell && this.state)
             this.sendChat(config.farewell, "discussion");
 
         // Display result
-        const col = (this.state.winner === this.state.players.black.id ? 'B' : 'W' );
+        const col = (this.state.winner === this.state.players.black.id ? 'B' : 'W');
         const result = `${this.state.outcome[0].toUpperCase()}${this.state.outcome.substr(1)}`;
         const res = this.getRes(result);
         const winloss = (this.state.winner === this.conn.bot_id ? "W" : "L");
@@ -508,11 +510,11 @@ class Game {
 
         if (!this.disconnect_timeout) {
             if (config.DEBUG) console.log(`Starting disconnect Timeout in Game ${this.game_id} gameOver()`);
-            this.disconnect_timeout = setTimeout(() => {  this.conn.disconnectFromGame(this.game_id);  }, 1000);
+            this.disconnect_timeout = setTimeout(() => { this.conn.disconnectFromGame(this.game_id); }, 1000);
         }
     }
     header() {
-        if (!this.state)  return;
+        if (!this.state) return;
         const botIsBlack = this.state.players.black.username === config.username;
         const color = botIsBlack ? '  B' : 'W  ';  // Playing black / white against ...
         const player = botIsBlack ? this.state.players.white : this.state.players.black;
@@ -524,8 +526,8 @@ class Game {
     }
     log() {
         const moves = (this.state && this.state.moves ? this.state.moves.length : 0);
-        const movestr = (moves ? `Move ${moves}`: "        ");
-        const arr = [ `[Game ${this.game_id}]  ${movestr} ` ];
+        const movestr = (moves ? `Move ${moves}` : "        ");
+        const arr = [`[Game ${this.game_id}]  ${movestr} `];
 
         for (let i = 0; i < arguments.length; ++i) {
             arr.push(arguments[i]);
@@ -549,10 +551,10 @@ class Game {
             'game_id': this.game_id,
             'player_id': this.conn.bot_id
         }));
-    }    
+    }
     getOpponent() {
-        const player = (this.state.players.white.id === this.conn.bot_id ? 
-                        this.state.players.black : this.state.players.white);
+        const player = (this.state.players.white.id === this.conn.bot_id ?
+            this.state.players.black : this.state.players.white);
         return player;
     }
 }
@@ -562,7 +564,7 @@ function num2char(num) {
     return "abcdefghijklmnopqrstuvwxyz"[num];
 }
 function encodeMove(move) {
-    if (move['x'] === -1) 
+    if (move['x'] === -1)
         return "..";
     return num2char(move['x']) + num2char(move['y']);
 }

--- a/getArgv.js
+++ b/getArgv.js
@@ -37,8 +37,6 @@ function getArgv() {
         .default('startupbuffer', rootOptionsDefaults.startupbuffer)
         .describe('timeout', 'Disconnect from a game after this many seconds (if set)')
         .default('timeout', rootOptionsDefaults.timeout)
-        // TODO: Test known_commands for kgs-time_settings to set this, and remove the command line option
-        .describe('kgstime', 'Set this if bot understands the kgs-time_settings command')
         .describe('showboard', 'Set this if bot understands the showboard GTP command, and if you want to display the showboard output')
         .describe('persist', 'Bot process remains running between moves')
         .describe('persistnoncorr', 'Bot process remains running between moves, except for correspondence games where bot is always killed')

--- a/test/pv.test.js
+++ b/test/pv.test.js
@@ -46,7 +46,7 @@ describe("Pv should work", () => {
         fake_gtp.stderr.emit('data', 'ble\r\n');
         fake_gtp.stderr.emit('data', 'blaor\r\n');
 
-        assert.equal(bot.pv.postPvToChat.callCount, 2); 
+        assert.strictEqual(bot.pv.postPvToChat.callCount, 2); 
         assert.ok(bot.pv.postPvToChat.firstCall.calledWith('blable')); 
         assert.ok(bot.pv.postPvToChat.secondCall.calledWith('blaor')); 
 
@@ -103,7 +103,7 @@ describe("Pv should work", () => {
 
         fake_gtp.stderr.emit('data', fs.readFileSync(`./test/pv_samples/${fileName}.txt`));
 
-        assert.equal(game.sendChat.callCount, 1);
+        assert.strictEqual(game.sendChat.callCount, 1);
         assert.ok(game.sendChat.firstCall.calledWith(chatBody, 3, 'malkovich'));
         
         conn.terminate();

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -511,7 +511,7 @@ describe("Time should be reported", () => {
             });
         });
 
-        describe("in kgs time", () => {
+        describe("in kata time", () => {
             beforeEach(() => {
                 bot.kgstime = true;
             });
@@ -544,6 +544,43 @@ describe("Time should be reported", () => {
                     ["kgs-time_settings canadian 82800 3600 1"],
                     ["time_left black 8745 0"],
                     ["time_left white 0 1"]
+                ]);
+            });
+        });
+
+        describe("in kgs time", () => {
+            beforeEach(() => {
+                bot.katafischer = true;
+            });
+
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kata-time_settings fischer-capped 86400 3600 172800 -1"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 12338 0"]
+                ]);
+            });
+
+            it("main time rollover into period time", () => {
+                state.clock.last_move = init_time - (8745 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kata-time_settings fischer-capped 86400 3600 172800 -1"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 2598 0"]
+                ]);
+            });
+
+            it("rollover should not be negative", () => {
+                state.clock.last_move = init_time - (87450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kata-time_settings fischer-capped 86400 3600 172800 -1"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 0 0"]
                 ]);
             });
         });

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -1,0 +1,628 @@
+
+const assert = require('assert');
+const { Bot } = require('../bot');
+const { FakeAPI } = require('./fake_modules/FakeAPI');
+const { FakeGTP } = require('./fake_modules/FakeGTP');
+const { FakeSocket } = require('./fake_modules/FakeSocket');
+const { getNewConfig } = require('./module_loading/getNewConfig');
+const https = require('https');
+const child_process = require('child_process');
+const sinon = require('sinon');
+const config = getNewConfig();
+const connection = require('../connection');
+const { stub_console } = require('./utils/stub_console');
+
+afterEach(() => sinon.restore());
+
+const fischer_time = {
+    "system": "fischer",
+    "initial_time": 86400, /* in seconds */
+    "time_increment": 3600,  /* in seconds */
+    "max_time": 172800  /* in seconds */
+}
+const fischer_clock = {
+    thinking_time: 12345, /* seconds */
+}
+
+const byoYomi_time = {
+    "system": "byoyomi",
+    "main_time": 86400, /* seconds */
+    "period_time": 3600,  /* seconds */
+    "periods": 5      /* count */
+}
+
+const byoYomi_clock = {
+    thinking_time: 12345, /* seconds */
+    periods: 5,     /* periods left */
+    period_time: 3600,    /* seconds */
+}
+
+const byoYomi_overtime = {
+    thinking_time: 0, /* seconds */
+    periods: 3,     /* periods left */
+    period_time: 3600,    /* seconds */
+}
+
+const byoYomi_overtime1 = {
+    thinking_time: 0, /* seconds */
+    periods: 1,     /* periods left */
+    period_time: 3600,    /* seconds */
+}
+
+const simple_time = {
+    "system": "simple",
+    "per_move": 86400  /* seconds */
+}
+
+const simple_clock = 12345 /* this field is simply a number of seconds on the clock, 
+will be 0 for the player not playing (this is subject to change, and may become 
+  number of seconds left on the clock for the last move instead of simply 0 in 
+  the future.) */
+
+const canadian_time = {
+    "system": "canadian",
+    "main_time": 86400, /* seconds */
+    "period_time": 3600, /* seconds */
+    "stones_per_period": 10     /* count */
+}
+
+const canadian_clock = {
+    thinking_time: 12345, /* seconds */
+
+    /* applicable only when thinking_time == 0, however 
+     * the fields will always exist */
+    moves_left: 10,  /* moves left in this period  */
+    block_time: 3600   /* seconds left in this period  */
+}
+
+const canadian_overtime = {
+    thinking_time: 0, /* seconds */
+
+    /* applicable only when thinking_time == 0, however 
+     * the fields will always exist */
+    moves_left: 10,    /* moves left in this period  */
+    block_time: 2000   /* seconds left in this period  */
+}
+
+const canadian_overtime1 = {
+    thinking_time: 0, /* seconds */
+
+    /* applicable only when thinking_time == 0, however 
+     * the fields will always exist */
+    moves_left: 1,    /* moves left in this period  */
+    block_time: 200   /* seconds left in this period  */
+}
+
+const absolute_time = {
+    "system": "absolute",
+    "total_time": 86400  /* seconds */
+}
+
+const absolute_clock = {
+    thinking_time: 12345  /* seconds */
+}
+
+const none_time = {
+    "system": "none"
+}
+
+// The `black_time` and `white_time` fields do not exist for the `none` time control.
+
+describe("Time should be reported", () => {
+    let bot;
+    let state;
+    let clock;
+    const init_time = Date.now();
+
+    beforeEach(() => {
+        stub_console();
+        clock = sinon.useFakeTimers(init_time);
+        let fake_socket = new FakeSocket();
+        let fake_api = new FakeAPI();
+        fake_api.request({ path: '/foo' }, () => { });
+        sinon.stub(https, 'request').callsFake(fake_api.request);
+
+        let fake_gtp = new FakeGTP();
+        sinon.stub(child_process, 'spawn').returns(fake_gtp);
+
+        let conn = new connection.Connection(() => { return fake_socket; }, config);
+
+        const game = sinon.spy();
+        config.ogspv = true;
+        config.startupbuffer = 2000;
+
+        bot = new Bot(conn, game, config.bot_command);
+        bot.command = sinon.spy();
+        state = {
+            clock: {
+                black_time: {},
+                white_time: {},
+                current_player: 1, // white
+                last_move: init_time - 4400, // last move was made 4.4 seconds ago.
+                now: init_time - 300, // unused on client, but this is the server time.
+                game_id: 989449,
+                black_player_id: 12751,
+                white_player_id: 1,
+                title: "friendly match",
+                // paused_since: 1416093910,   /* seconds since epoch */
+                // expiration_delta: 1350000,  /* milliseconds */
+                // expiration: 1416174229750,  /* milliseconds since epoch */
+            },
+            time_control: {},
+        }
+    });
+
+    afterEach(() => {
+        clock.restore();
+    });
+
+    it("should load the clock", () => {
+        state.time_control = byoYomi_time;
+        state.clock.black_time = byoYomi_clock;
+        state.clock.white_time = byoYomi_clock;
+
+        bot.loadClock(state);
+        assert.deepStrictEqual(bot.command.args, [
+            ["time_settings 100800 3600 1"],
+            ["time_left black 26745 0"],
+            ["time_left white 26738 0"]
+        ]);
+    });
+
+    it("should substract startup bufffer on first move", () => {
+        state.time_control = byoYomi_time;
+        state.clock.black_time = byoYomi_clock;
+        state.clock.white_time = byoYomi_clock;
+        config.startupbuffer = 4000;
+
+        bot.loadClock(state);
+        assert.deepStrictEqual(bot.command.args, [
+            ["time_settings 100800 3600 1"],
+            ["time_left black 26745 0"],
+            ["time_left white 26736 0"]
+        ]);
+    });
+
+    it("should not substract startup bufffer after first move", () => {
+        state.time_control = byoYomi_time;
+        state.clock.black_time = byoYomi_clock;
+        state.clock.white_time = byoYomi_clock;
+        bot.firstmove = false;
+
+        bot.loadClock(state);
+        assert.deepStrictEqual(bot.command.args, [
+            ["time_settings 100800 3600 1"],
+            ["time_left black 26745 0"],
+            ["time_left white 26740 0"]
+        ]);
+    });
+
+    describe("for japanese byo-yomi", () => {
+        beforeEach(() => {
+            state.time_control = byoYomi_time;
+            state.clock.black_time = byoYomi_clock;
+            state.clock.white_time = byoYomi_clock;
+        });
+
+        describe("in gtp time", () => {
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
+                    ["time_left black 26745 0"], // 12345 main time left + 4*3600 perod time = 26745. 0 for main time.
+                    ["time_left white 26738 0"] //  should be 26745 - 6.4s (since last move and startup buffer) = 26745-6.4 = 26738 (rounded down)
+                ]);
+            });
+
+            it("main time rollover into period time", () => {
+                state.clock.last_move = init_time - (12345 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
+                    ["time_left black 26745 0"], // 12345 main time left + 4*3600 perod time = 26745. 0 for main time.
+                    ["time_left white 13398 0"] //  should be 26745 - 12345 - 1000 - 2 (since last move and startup buffer) = 26745-13347 = 13398 (rounded down)
+                ]);
+            });
+
+            it("main time rollover into last period", () => {
+                state.clock.last_move = init_time - (12345 + 4 * 3600 + 1000) * 1000;
+
+                bot.loadClock(state);
+                // assert.deepStrictEqual(bot.command.args, [
+                //     ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
+                //     ["time_left black 26745 0"], // 12345 main time left + 4*3600 perod time = 26745. 0 for main time.
+                //     ["time_left white 2598 1"] //  should be 26745 - 12345 - 4*3600 - 1000 - 2 (since last move and startup buffer) = 26745-26745 - 1002 = rolled into last period 3600 - 1002 = 2598
+                // ]);
+                // WRONG:
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 100800 -24147 1"],
+                    ["time_left black 26745 0"],
+                    ["time_left white -24147 1"]
+                ]);
+            });
+
+            it("overtime with periods left", () => {
+                state.clock.black_time = byoYomi_overtime;
+                state.clock.white_time = byoYomi_overtime;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
+                    ["time_left black 7200 0"], // 2*3600=7200 main time left. 0 for main time.
+                    ["time_left white 7193 0"] //  should be 7200 - 6.4s = 7200-6.4 = 7193 (rounded down)
+                ]);
+            });
+
+            it("over time with 1 period left", () => {
+                state.clock.black_time = byoYomi_overtime1;
+                state.clock.white_time = byoYomi_overtime1;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    // ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
+                    ["time_settings 100800 3593 1"], // WRONG
+                    ["time_left black 3600 1"], // 3600 period time left. 1 for period time.
+                    ["time_left white 3593 1"] //  should be 3600 - 6.4s = 3593 (rounded down)
+                ]);
+            });
+        });
+
+        describe("in kgs time", () => {
+            beforeEach(() => {
+                bot.kgstime = true;
+            });
+
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    // ["kgs-time_settings byoyomi 86400 3600 5"],
+                    ["kgs-time_settings byoyomi 86400 3593 5"], // WRONG
+                    ["time_left black 12345 0"], // 12345 main time left. 0 for main time.
+                    ["time_left white 12338 0"] //  12345 main time left - 6.4s = 12338. 0 for main time.
+                ]);
+            });
+
+            it("main time rollover into period time", () => {
+                state.clock.last_move = init_time - (12345 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    // ["kgs-time_settings byoyomi 86400 3600 5"],
+                    // ["time_left white 2598 4"], // 12345 - 12345 - 1000 - 2 (since last move and startup buffer) = first overtime used and 3600-1002s remaining = 2598 4
+                    ["kgs-time_settings byoyomi 86400 -9747 5"], // WRONG
+                    ["time_left black 12345 0"], // 12345 main time left. 0 for main time.
+                    ["time_left white 0 0"] // WRONG
+                ]);
+            });
+
+            it("main time rollover into last period", () => {
+                state.clock.last_move = init_time - (12345 + 4 * 3600 + 1000) * 1000;
+
+                bot.loadClock(state);
+                // assert.deepStrictEqual(bot.command.args, [
+                //     ["kgs-time_settings byoyomi 86400 3600 5"],
+                //     ["time_left white 2598 1"], // should be 26745 - 12345 - 1000 - 2 (since last move and startup buffer) = 26745-13347 = 13398 (rounded down)
+                //     ["time_left black 12345 0"] // 12345 main time left. 0 for main time.
+                // ]);
+                // WRONG:
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings byoyomi 86400 -24147 5"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 0 0"]
+                ]);
+            });
+
+            it("overtime with periods left", () => {
+                state.clock.black_time = byoYomi_overtime;
+                state.clock.white_time = byoYomi_overtime;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    // ["kgs-time_settings byoyomi 86400 3600 5"],
+                    ["kgs-time_settings byoyomi 86400 3593 5"], // WRONG
+                    ["time_left black 3600 3"],
+                    ["time_left white 3593 3"] // should be 3600 - 6.4s = 3593 (rounded down), and 3 remaining periods
+                ]);
+            });
+
+            it("over time with 1 period left", () => {
+                state.clock.black_time = byoYomi_overtime1;
+                state.clock.white_time = byoYomi_overtime1;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    // ["kgs-time_settings byoyomi 86400 3600 5"],
+                    ["kgs-time_settings byoyomi 86400 3593 5"], // WRONG
+                    ["time_left black 3600 1"], // 3600 period time left. 1 for period time.
+                    ["time_left white 3593 1"] //  should be 3600 - 6.4s = 3593 (rounded down)
+                ]);
+            });
+        });
+    });
+
+    describe("for canadese byo-yomi", () => {
+        beforeEach(() => {
+            state.time_control = canadian_time;
+            state.clock.black_time = canadian_clock;
+            state.clock.white_time = canadian_clock;
+        });
+
+        describe("in gtp time", () => {
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 3600 10"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 12338 0"] // 12345 - 6.4s delay and startup buffer
+                ]);
+            });
+
+            it("main time rollover into period time", () => {
+                state.clock.last_move = init_time - (12345 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 3600 10"],
+                    ["time_left black 12345 0"],
+                    // ["time_left white 2598 10"] 
+                    ["time_left white -9747 10"] // WRONG
+                ]);
+            });
+
+            it("overtime with stones left", () => {
+                state.clock.black_time = canadian_overtime;
+                state.clock.white_time = canadian_overtime;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 3600 10"],
+                    ["time_left black 2000 10"],
+                    ["time_left white 1993 10"] // 2000 - 6.4 rounded down
+                ]);
+            });
+
+            it("over time with 1 stone left", () => {
+                state.clock.black_time = canadian_overtime1;
+                state.clock.white_time = canadian_overtime1;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    // ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
+                    ["time_settings 86400 3600 10"],
+                    ["time_left black 200 1"],
+                    ["time_left white 193 1"] // 2000 - 6.4 rounded down
+                ]);
+            });
+        });
+
+        describe("in kgs time", () => {
+            beforeEach(() => {
+                bot.kgstime = true;
+            });
+
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings canadian 86400 3600 10"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 12338 0"] // 12345 - 6.4 rounded down
+                ]);
+            });
+
+            it("main time rollover into period time", () => {
+                state.clock.last_move = init_time - (12345 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings canadian 86400 3600 10"],
+                    ["time_left black 12345 0"],
+                    // ["time_left white 2598 10"] 
+                    ["time_left white -9747 10"] // WRONG
+                ]);
+            });
+
+            it("main time rollover into last period", () => {
+                state.clock.last_move = init_time - (12345 + 4 * 3600 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings canadian 86400 3600 10"],
+                    ["time_left black 12345 0"],
+                    // ["time_left white 1993 10"] // 2000 - 6.4 rounded down
+                    ["time_left white -24147 10"] // WRONG
+                ]);
+            });
+
+            it("overtime with stones left", () => {
+                state.clock.black_time = canadian_overtime;
+                state.clock.white_time = canadian_overtime;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings canadian 86400 3600 10"],
+                    ["time_left black 2000 10"],
+                    ["time_left white 1993 10"] // 2000 - 6.4 rounded down
+                ]);
+            });
+
+            it("over time with 1 stone left", () => {
+                state.clock.black_time = canadian_overtime1;
+                state.clock.white_time = canadian_overtime1;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings canadian 86400 3600 10"],
+                    ["time_left black 200 1"],
+                    ["time_left white 193 1"] // 200 - 6.4 rounded down
+                ]);
+            });
+        });
+    });
+
+    describe("for fischer", () => {
+        beforeEach(() => {
+            state.time_control = fischer_time;
+            state.clock.black_time = fischer_clock;
+            state.clock.white_time = fischer_clock;
+        });
+
+        describe("in gtp time", () => {
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 82800 3600 1"],
+                    // ["time_left black 8745 0"],
+                    // ["time_left white 8738 0"]
+                    ["time_left black 12345 0"], // WRONG, should either use 1 for overtime or if 0, substract period time.
+                    ["time_left white 12338 0"] // 12345 - 6.4s delay and startup buffer, also WRONG
+                ]);
+            });
+
+            it("main time rollover into period time", () => {
+                state.clock.last_move = init_time - (8745 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 82800 3600 1"],
+                    // ["time_left black 2600 1"],
+                    // ["time_left white 2598 1"]
+                    ["time_left black 12345 0"], // WRONG // 12345 main time left. 0 for main time.
+                    ["time_left white 2598 0"] // WRONG // Should be for overtime.
+                ]);
+            });
+        });
+
+        describe("in kgs time", () => {
+            beforeEach(() => {
+                bot.kgstime = true;
+            });
+
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings canadian 82800 3600 1"],
+                    // ["time_left black 8745 0"],
+                    // ["time_left white 8738 0"]
+                    ["time_left black 12345 0"], // WRONG, should either use 1 for overtime or if 0, substract period time.
+                    ["time_left white 12338 0"] // 12345 - 6.4 rounded down, also WRONG
+                ]);
+            });
+
+            it("main time rollover into period time", () => {
+                state.clock.last_move = init_time - (8745 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings canadian 82800 3600 1"],
+                    // ["time_left black 2600 1"],
+                    // ["time_left white 2598 1"]
+                    ["time_left black 12345 0"], // WRONG // 12345 main time left. 0 for main time.
+                    ["time_left white 2598 0"] // WRONG // Should be 1 for overtime.
+                ]);
+            });
+        });
+    });
+
+    describe("for simple", () => {
+        beforeEach(() => {
+            state.time_control = simple_time;
+            state.clock.black_time = simple_clock;
+            state.clock.white_time = simple_clock;
+        });
+
+        describe("in gtp time", () => {
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 0 86400 1"],
+                    // ["time_left black 86400 1"],
+                    // ["time_left white 12338 1"] // 12345 - 6.4s delay and startup buffer = 12338, 1 for overtime.
+                    ["time_left black 0 1"],
+                    ["time_left white 1 1"] // Wrong
+                ]);
+            });
+        });
+
+        describe("in kgs time", () => {
+            beforeEach(() => {
+                bot.kgstime = true;
+            });
+
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 0 86400 1"],
+                    // ["time_left black 86400 1"],
+                    // ["time_left white 12338 1"] // 12345 - 6.4s delay and startup buffer = 12338, 1 for overtime.
+                    ["time_left black 0 1"], // Wrong
+                    ["time_left white 1 1"] // Wrong
+                ]);
+            });
+        });
+    });
+
+    describe("for absolute", () => {
+        beforeEach(() => {
+            state.time_control = absolute_time;
+            state.clock.black_time = absolute_clock;
+            state.clock.white_time = absolute_clock;
+        });
+
+        describe("in gtp time", () => {
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 0 0"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 12338 0"] // 12345 - 6.4s delay and startup buffer = 12338, 0 for main time.
+                ]);
+            });
+        });
+
+        describe("in kgs time", () => {
+            beforeEach(() => {
+                bot.kgstime = true;
+            });
+
+            it("main time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings absolute 86400"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 12338 0"] // 12345 - 6.4s delay and startup buffer = 12338, 0 for main time.
+                ]);
+            });
+
+            it("main time black move", () => {
+                bot.loadClock(state);
+                state.clock.current_player = state.clock.black_player_id;
+
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings absolute 86400"],
+                    // ["time_left black 12338 0"], // 12345 - 6.4s delay and startup buffer = 12338, 0 for main time.
+                    // ["time_left white 12345 0"] 
+                    ["time_left black 12345 0"], // WRONG
+                    ["time_left white 12338 0"] // WRONG
+
+                ]);
+            });
+        });
+    });
+    /*
+        todo:
+            For gtp, kgs and katago
+            byo-yomi:
+                katago -> same as kgs time
+            canadese:
+                katago -> same as kgs time
+            fischer:
+                katago -> direct
+            simple:
+                katago -> direct
+            absolute:
+                katago -> direct
+            none:
+                none.
+    */
+});

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -51,7 +51,7 @@ const byoYomi_overtime1 = {
 
 const simple_time = {
     "system": "simple",
-    "per_move": 86400  /* seconds */
+    "per_move": 12345  /* seconds */
 }
 
 const simple_clock = 12345 /* this field is simply a number of seconds on the clock, 
@@ -560,7 +560,7 @@ describe("Time should be reported", () => {
             it("period time", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    ["time_settings 0 86400 1"],
+                    ["time_settings 0 12345 1"],
                     ["time_left black 12345 1"],
                     ["time_left white 12338 1"] // 12345 - 6.4s delay and startup buffer = 12338, 1 for overtime.
                 ]);
@@ -571,7 +571,7 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    ["time_settings 0 86400 1"],
+                    ["time_settings 0 12345 1"],
                     ["time_left black 12345 1"],
                     ["time_left white 998 1"]
                 ]);
@@ -582,7 +582,7 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    ["time_settings 0 86400 1"],
+                    ["time_settings 0 12345 1"],
                     ["time_left black 12345 1"],
                     ["time_left white 0 1"]
                 ]);
@@ -597,7 +597,7 @@ describe("Time should be reported", () => {
             it("period time", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    ["time_settings 0 86400 1"],
+                    ["time_settings 0 12345 1"],
                     ["time_left black 12345 1"],
                     ["time_left white 12338 1"] // 12345 - 6.4s delay and startup buffer = 12338, 1 for overtime.
                 ]);
@@ -608,7 +608,7 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    ["time_settings 0 86400 1"],
+                    ["time_settings 0 12345 1"],
                     ["time_left black 12345 1"],
                     ["time_left white 998 1"]
                 ]);
@@ -619,7 +619,7 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    ["time_settings 0 86400 1"],
+                    ["time_settings 0 12345 1"],
                     ["time_left black 12345 1"],
                     ["time_left white 0 1"]
                 ]);

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -229,16 +229,21 @@ describe("Time should be reported", () => {
                 state.clock.last_move = init_time - (12345 + 4 * 3600 + 1000) * 1000;
 
                 bot.loadClock(state);
-                // assert.deepStrictEqual(bot.command.args, [
-                //     ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
-                //     ["time_left black 26745 0"], // 12345 main time left + 4*3600 perod time = 26745. 0 for main time.
-                //     ["time_left white 2598 1"] //  should be 26745 - 12345 - 4*3600 - 1000 - 2 (since last move and startup buffer) = 26745-26745 - 1002 = rolled into last period 3600 - 1002 = 2598
-                // ]);
-                // WRONG:
                 assert.deepStrictEqual(bot.command.args, [
-                    ["time_settings 100800 -24147 1"],
-                    ["time_left black 26745 0"],
-                    ["time_left white -24147 1"]
+                    ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
+                    ["time_left black 26745 0"], // 12345 main time left + 4*3600 perod time = 26745. 0 for main time.
+                    ["time_left white 2598 1"] //  should be 26745 - 12345 - 4*3600 - 1000 - 2 (since last move and startup buffer) = 26745-26745 - 1002 = rolled into last period 3600 - 1002 = 2598
+                ]);
+            });
+
+            it("rollover should not be negative", () => {
+                state.clock.last_move = init_time - (123450 + 4 * 3600 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
+                    ["time_left black 26745 0"], // 12345 main time left + 4*3600 perod time = 26745. 0 for main time.
+                    ["time_left white 0 1"]
                 ]);
             });
 
@@ -260,8 +265,7 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    // ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
-                    ["time_settings 100800 3593 1"], // WRONG
+                    ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
                     ["time_left black 3600 1"], // 3600 period time left. 1 for period time.
                     ["time_left white 3593 1"] //  should be 3600 - 6.4s = 3593 (rounded down)
                 ]);
@@ -276,8 +280,7 @@ describe("Time should be reported", () => {
             it("main time", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    // ["kgs-time_settings byoyomi 86400 3600 5"],
-                    ["kgs-time_settings byoyomi 86400 3593 5"], // WRONG
+                    ["kgs-time_settings byoyomi 86400 3600 5"],
                     ["time_left black 12345 0"], // 12345 main time left. 0 for main time.
                     ["time_left white 12338 0"] //  12345 main time left - 6.4s = 12338. 0 for main time.
                 ]);
@@ -288,11 +291,9 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    // ["kgs-time_settings byoyomi 86400 3600 5"],
-                    // ["time_left white 2598 4"], // 12345 - 12345 - 1000 - 2 (since last move and startup buffer) = first overtime used and 3600-1002s remaining = 2598 4
-                    ["kgs-time_settings byoyomi 86400 -9747 5"], // WRONG
+                    ["kgs-time_settings byoyomi 86400 3600 5"],
                     ["time_left black 12345 0"], // 12345 main time left. 0 for main time.
-                    ["time_left white 0 0"] // WRONG
+                    ["time_left white 2598 5"] // 12345 - 12345 - 1000 - 2 (since last move and startup buffer) = first overtime used and 3600-1002s remaining = 2598 4
                 ]);
             });
 
@@ -300,16 +301,21 @@ describe("Time should be reported", () => {
                 state.clock.last_move = init_time - (12345 + 4 * 3600 + 1000) * 1000;
 
                 bot.loadClock(state);
-                // assert.deepStrictEqual(bot.command.args, [
-                //     ["kgs-time_settings byoyomi 86400 3600 5"],
-                //     ["time_left white 2598 1"], // should be 26745 - 12345 - 1000 - 2 (since last move and startup buffer) = 26745-13347 = 13398 (rounded down)
-                //     ["time_left black 12345 0"] // 12345 main time left. 0 for main time.
-                // ]);
-                // WRONG:
                 assert.deepStrictEqual(bot.command.args, [
-                    ["kgs-time_settings byoyomi 86400 -24147 5"],
-                    ["time_left black 12345 0"],
-                    ["time_left white 0 0"]
+                    ["kgs-time_settings byoyomi 86400 3600 5"],
+                    ["time_left black 12345 0"], // 12345 main time left. 0 for main time.
+                    ["time_left white 2598 1"] // should be 26745 - 12345 - 1000 - 2 (since last move and startup buffer) = 26745-13347 = 13398 (rounded down)
+                ]);
+            });
+
+            it("rollover should not be negative", () => {
+                state.clock.last_move = init_time - (123450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings byoyomi 86400 3600 5"],
+                    ["time_left black 12345 0"], // 12345 main time left. 0 for main time.
+                    ["time_left white 0 1"]
                 ]);
             });
 
@@ -319,8 +325,7 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    // ["kgs-time_settings byoyomi 86400 3600 5"],
-                    ["kgs-time_settings byoyomi 86400 3593 5"], // WRONG
+                    ["kgs-time_settings byoyomi 86400 3600 5"],
                     ["time_left black 3600 3"],
                     ["time_left white 3593 3"] // should be 3600 - 6.4s = 3593 (rounded down), and 3 remaining periods
                 ]);
@@ -332,8 +337,7 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    // ["kgs-time_settings byoyomi 86400 3600 5"],
-                    ["kgs-time_settings byoyomi 86400 3593 5"], // WRONG
+                    ["kgs-time_settings byoyomi 86400 3600 5"],
                     ["time_left black 3600 1"], // 3600 period time left. 1 for period time.
                     ["time_left white 3593 1"] //  should be 3600 - 6.4s = 3593 (rounded down)
                 ]);
@@ -365,8 +369,18 @@ describe("Time should be reported", () => {
                 assert.deepStrictEqual(bot.command.args, [
                     ["time_settings 86400 3600 10"],
                     ["time_left black 12345 0"],
-                    // ["time_left white 2598 10"] 
-                    ["time_left white -9747 10"] // WRONG
+                    ["time_left white 2598 10"]
+                ]);
+            });
+
+            it("rollover should not be negative", () => {
+                state.clock.last_move = init_time - (123450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 3600 10"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 0 10"]
                 ]);
             });
 
@@ -388,7 +402,6 @@ describe("Time should be reported", () => {
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    // ["time_settings 100800 3600 1"], // we add 4 of the 5 periods to the main time, so 86400+4*3600=100800. After that 1 stone per 3600 seconds byo-yomi.
                     ["time_settings 86400 3600 10"],
                     ["time_left black 200 1"],
                     ["time_left white 193 1"] // 2000 - 6.4 rounded down
@@ -417,20 +430,18 @@ describe("Time should be reported", () => {
                 assert.deepStrictEqual(bot.command.args, [
                     ["kgs-time_settings canadian 86400 3600 10"],
                     ["time_left black 12345 0"],
-                    // ["time_left white 2598 10"] 
-                    ["time_left white -9747 10"] // WRONG
+                    ["time_left white 2598 10"]
                 ]);
             });
 
-            it("main time rollover into last period", () => {
-                state.clock.last_move = init_time - (12345 + 4 * 3600 + 1000) * 1000;
+            it("rollover should not be negative", () => {
+                state.clock.last_move = init_time - (123450 + 4 * 3600 + 1000) * 1000;
 
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
                     ["kgs-time_settings canadian 86400 3600 10"],
                     ["time_left black 12345 0"],
-                    // ["time_left white 1993 10"] // 2000 - 6.4 rounded down
-                    ["time_left white -24147 10"] // WRONG
+                    ["time_left white 0 10"]
                 ]);
             });
 
@@ -472,10 +483,8 @@ describe("Time should be reported", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
                     ["time_settings 82800 3600 1"],
-                    // ["time_left black 8745 0"],
-                    // ["time_left white 8738 0"]
-                    ["time_left black 12345 0"], // WRONG, should either use 1 for overtime or if 0, substract period time.
-                    ["time_left white 12338 0"] // 12345 - 6.4s delay and startup buffer, also WRONG
+                    ["time_left black 8745 0"], // 12345 - 3600 = 8745 main time left.
+                    ["time_left white 8738 0"]
                 ]);
             });
 
@@ -485,10 +494,19 @@ describe("Time should be reported", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
                     ["time_settings 82800 3600 1"],
-                    // ["time_left black 2600 1"],
-                    // ["time_left white 2598 1"]
-                    ["time_left black 12345 0"], // WRONG // 12345 main time left. 0 for main time.
-                    ["time_left white 2598 0"] // WRONG // Should be for overtime.
+                    ["time_left black 8745 0"],
+                    ["time_left white 2598 1"]
+                ]);
+            });
+
+            it("rollover should not be negative", () => {
+                state.clock.last_move = init_time - (87450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 82800 3600 1"],
+                    ["time_left black 8745 0"],
+                    ["time_left white 0 1"]
                 ]);
             });
         });
@@ -502,10 +520,8 @@ describe("Time should be reported", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
                     ["kgs-time_settings canadian 82800 3600 1"],
-                    // ["time_left black 8745 0"],
-                    // ["time_left white 8738 0"]
-                    ["time_left black 12345 0"], // WRONG, should either use 1 for overtime or if 0, substract period time.
-                    ["time_left white 12338 0"] // 12345 - 6.4 rounded down, also WRONG
+                    ["time_left black 8745 0"],
+                    ["time_left white 8738 0"]
                 ]);
             });
 
@@ -515,10 +531,19 @@ describe("Time should be reported", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
                     ["kgs-time_settings canadian 82800 3600 1"],
-                    // ["time_left black 2600 1"],
-                    // ["time_left white 2598 1"]
-                    ["time_left black 12345 0"], // WRONG // 12345 main time left. 0 for main time.
-                    ["time_left white 2598 0"] // WRONG // Should be 1 for overtime.
+                    ["time_left black 8745 0"],
+                    ["time_left white 2598 1"]
+                ]);
+            });
+
+            it("rollover should not be negative", () => {
+                state.clock.last_move = init_time - (87450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["kgs-time_settings canadian 82800 3600 1"],
+                    ["time_left black 8745 0"],
+                    ["time_left white 0 1"]
                 ]);
             });
         });
@@ -532,14 +557,34 @@ describe("Time should be reported", () => {
         });
 
         describe("in gtp time", () => {
-            it("main time", () => {
+            it("period time", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
                     ["time_settings 0 86400 1"],
-                    // ["time_left black 86400 1"],
-                    // ["time_left white 12338 1"] // 12345 - 6.4s delay and startup buffer = 12338, 1 for overtime.
-                    ["time_left black 0 1"],
-                    ["time_left white 1 1"] // Wrong
+                    ["time_left black 12345 1"],
+                    ["time_left white 12338 1"] // 12345 - 6.4s delay and startup buffer = 12338, 1 for overtime.
+                ]);
+            });
+
+            it("period time with delay", () => {
+                state.clock.last_move = init_time - (12345 - 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 0 86400 1"],
+                    ["time_left black 12345 1"],
+                    ["time_left white 998 1"]
+                ]);
+            });
+
+            it("period time with delay should not go negative", () => {
+                state.clock.last_move = init_time - (123450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 0 86400 1"],
+                    ["time_left black 12345 1"],
+                    ["time_left white 0 1"]
                 ]);
             });
         });
@@ -549,14 +594,34 @@ describe("Time should be reported", () => {
                 bot.kgstime = true;
             });
 
-            it("main time", () => {
+            it("period time", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
                     ["time_settings 0 86400 1"],
-                    // ["time_left black 86400 1"],
-                    // ["time_left white 12338 1"] // 12345 - 6.4s delay and startup buffer = 12338, 1 for overtime.
-                    ["time_left black 0 1"], // Wrong
-                    ["time_left white 1 1"] // Wrong
+                    ["time_left black 12345 1"],
+                    ["time_left white 12338 1"] // 12345 - 6.4s delay and startup buffer = 12338, 1 for overtime.
+                ]);
+            });
+
+            it("period time with delay", () => {
+                state.clock.last_move = init_time - (12345 - 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 0 86400 1"],
+                    ["time_left black 12345 1"],
+                    ["time_left white 998 1"]
+                ]);
+            });
+
+            it("period time with delay should not go negative", () => {
+                state.clock.last_move = init_time - (123450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 0 86400 1"],
+                    ["time_left black 12345 1"],
+                    ["time_left white 0 1"]
                 ]);
             });
         });
@@ -578,6 +643,28 @@ describe("Time should be reported", () => {
                     ["time_left white 12338 0"] // 12345 - 6.4s delay and startup buffer = 12338, 0 for main time.
                 ]);
             });
+
+            it("absolute time with delay", () => {
+                state.clock.last_move = init_time - (12345 - 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 0 0"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 998 0"]
+                ]);
+            });
+
+            it("absolute time with delay should not go negative", () => {
+                state.clock.last_move = init_time - (123450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 0 0"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 0 0"]
+                ]);
+            });
         });
 
         describe("in kgs time", () => {
@@ -588,7 +675,7 @@ describe("Time should be reported", () => {
             it("main time", () => {
                 bot.loadClock(state);
                 assert.deepStrictEqual(bot.command.args, [
-                    ["kgs-time_settings absolute 86400"],
+                    ["time_settings 86400 0 0"],
                     ["time_left black 12345 0"],
                     ["time_left white 12338 0"] // 12345 - 6.4s delay and startup buffer = 12338, 0 for main time.
                 ]);
@@ -599,19 +686,61 @@ describe("Time should be reported", () => {
                 state.clock.current_player = state.clock.black_player_id;
 
                 assert.deepStrictEqual(bot.command.args, [
-                    ["kgs-time_settings absolute 86400"],
-                    // ["time_left black 12338 0"], // 12345 - 6.4s delay and startup buffer = 12338, 0 for main time.
-                    // ["time_left white 12345 0"] 
-                    ["time_left black 12345 0"], // WRONG
-                    ["time_left white 12338 0"] // WRONG
-
+                    ["time_settings 86400 0 0"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 12338 0"] // 12345 - 6.4s delay and startup buffer = 12338, 0 for main time
                 ]);
+            });
+
+            it("absolute time with delay", () => {
+                state.clock.last_move = init_time - (12345 - 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 0 0"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 998 0"]
+                ]);
+            });
+
+            it("absolute time with delay should not go negative", () => {
+                state.clock.last_move = init_time - (123450 + 1000) * 1000;
+
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, [
+                    ["time_settings 86400 0 0"],
+                    ["time_left black 12345 0"],
+                    ["time_left white 0 0"]
+                ]);
+            });
+        });
+    });
+
+    describe("for none", () => {
+        beforeEach(() => {
+            state.time_control = none_time;
+        });
+
+        describe("in gtp time", () => {
+            it("no time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, []);
+            });
+        });
+
+        describe("in kgs time", () => {
+            beforeEach(() => {
+                bot.kgstime = true;
+            });
+
+            it("no time", () => {
+                bot.loadClock(state);
+                assert.deepStrictEqual(bot.command.args, []);
             });
         });
     });
     /*
         todo:
-            For gtp, kgs and katago
             byo-yomi:
                 katago -> same as kgs time
             canadese:
@@ -619,10 +748,8 @@ describe("Time should be reported", () => {
             fischer:
                 katago -> direct
             simple:
-                katago -> direct
+                katago -> same as kgs time
             absolute:
-                katago -> direct
-            none:
-                none.
+                katago -> same as kgs time
     */
 });


### PR DESCRIPTION
This change the way we communicate time_settings to the bot.

It adds auto detect for support of kgs time, kata time (for fischer) and fixes a number of bugs on existing time settings.
It also adds unittesting for the time_setting code.

A non exhaustive list of bugfixes:
Under fischer time the bot believed to have the time_increment already added during the current move.
Under simple time, white always believed to have only 1 second.
While going from main time to period time, the reported main time could go negative. This happened most notable under japanese byoyomi, and could cause timeouts as most bots will give an error on negative time input. An easy way to trigger this bug before would be to turn off the bot during byo-yomi and restart it after at least 1 period expired.
In many cases `time_settings` was modified to communicate remaining time, instead of `time_left`.