### PR TITLE
fixed sai pv score code

### DIFF
--- a/pv.js
+++ b/pv.js
@@ -6,7 +6,7 @@ class Pv {
     constructor(setting, game) {
         this.game = game;
         this.lookingForPv = false;
-        if (setting === 'SAI') { 
+        if (['SAI', 'SAI18'].includes(setting)) { 
             this.saiScore = false;
         } else {
             this.startupCheckSai = () => {}; // disable sai check for other bots.
@@ -111,10 +111,11 @@ class Pv {
     getPvChatSAI18(stop) {
         const winrate   = this.pvLine[5],
               score     = this.game.my_color === "black" ? this.pvLine[11] : -parseFloat(this.pvLine[11]),
+              scoreLine = this.saiScore ? `, Score: ${score}` : "",
               visits    = stop[1],
               playouts  = stop[3],
               // nps    = stop[4]; // unused
-              name      = `Winrate: ${winrate}%, Score: ${score}, Visits: ${visits}, Playouts: ${playouts}`,
+              name      = `Winrate: ${winrate}%${scoreLine}, Visits: ${visits}, Playouts: ${playouts}`,
               pv = this.PvToGtp(this.pvLine[13]);
 
         return this.createMessage(name, pv);


### PR DESCRIPTION
When i updated sai pv for sai 0.18.x, i got lazy and made it always show score.

I forgot why i had the alpha head check, but recently remembered when i saw my leela net bots on sai.exe post a score of 0.0 and -0.0.

This check will prevent score in pv if net does not have a score output.