### PR TITLE
Add support for a secondary "Resign Bot"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
         "@typescript-eslint",
         "@typescript-eslint/tslint",
         "prettier",
-        "react-hooks",
     ],
     extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
     rules: {
@@ -125,7 +124,6 @@ module.exports = {
                 },
             },
         ],
-        "react-hooks/rules-of-hooks": "error",
         "prefer-const": [
             "error",
             {

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,6 +1,7 @@
 const gulp = require("gulp");
 const gulpEslint = require("gulp-eslint-new");
 var ts = require("gulp-typescript");
+var sourcemaps = require("gulp-sourcemaps");
 var tsProject = ts.createProject("tsconfig.json");
 
 const ts_sources = ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.test.ts", "!src/**/*.test.tsx"];
@@ -21,10 +22,17 @@ function watch_build(done) {
     done();
 }
 
-function build() {
-    return tsProject.src().pipe(tsProject()).js.pipe(gulp.dest("dist"));
-}
+function build(done) {
+    //return tsProject.src().pipe(tsProject()).js.pipe(gulp.dest("dist"));
 
+    return tsProject
+        .src()
+        .pipe(sourcemaps.init())
+        .pipe(tsProject())
+        .pipe(sourcemaps.write("../dist"))
+        .pipe(gulp.dest("dist"))
+        .on("end", done);
+}
 
 function eslint() {
     return gulp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gtp2ogs",
-    "version": "7.0.0",
+    "version": "7.1.0-beta.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gtp2ogs",
-            "version": "7.0.0",
+            "version": "7.1.0-beta.1",
             "license": "ISC",
             "dependencies": {
                 "socket.io-client": "^4.1.2",
@@ -18,18 +18,17 @@
                 "gtp2ogs": "dist/gtp2ogs.js"
             },
             "devDependencies": {
-                "@types/node": "^16.11.6",
-                "@typescript-eslint/eslint-plugin": "^5.26.0",
-                "@typescript-eslint/eslint-plugin-tslint": "^5.26.0",
-                "@typescript-eslint/parser": "^5.26.0",
-                "eslint": "^8.16.0",
-                "eslint-config-prettier": "^8.5.0",
+                "@types/node": "^18.11.18",
+                "@typescript-eslint/eslint-plugin": "^5.48.0",
+                "@typescript-eslint/eslint-plugin-tslint": "^5.48.0",
+                "@typescript-eslint/parser": "^5.48.0",
+                "eslint": "^8.31.0",
+                "eslint-config-prettier": "^8.6.0",
                 "eslint-plugin-import": "^2.26.0",
-                "eslint-plugin-jsdoc": "^39.3.1",
+                "eslint-plugin-jsdoc": "^39.6.4",
                 "eslint-plugin-prefer-arrow": "^1.2.3",
-                "eslint-plugin-prettier": "^4.0.0",
-                "eslint-plugin-react-hooks": "^4.5.0",
-                "eslint-plugin-unicorn": "^42.0.0",
+                "eslint-plugin-prettier": "^4.2.1",
+                "eslint-plugin-unicorn": "^45.0.2",
                 "gulp": "^4.0.2",
                 "gulp-eslint-new": "^1.4.4",
                 "gulp-sourcemaps": "^3.0.0",
@@ -38,10 +37,10 @@
                 "markdownlint-cli": "^0.32.2",
                 "mocha": "^10.0.0",
                 "nyc": "^15.0.1",
-                "prettier": "2.6.2",
-                "prettier-eslint": "^15.0.0",
+                "prettier": "2.8.2",
+                "prettier-eslint": "^15.0.1",
                 "sinon": "^9.0.2",
-                "typescript": "^4.7.2"
+                "typescript": "^4.9.4"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -195,9 +194,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-            "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+            "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -336,9 +335,9 @@
             }
         },
         "node_modules/@es-joy/jsdoccomment": {
-            "version": "0.31.0",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz",
-            "integrity": "sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==",
+            "version": "0.36.1",
+            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+            "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
             "dev": true,
             "dependencies": {
                 "comment-parser": "1.3.1",
@@ -346,19 +345,34 @@
                 "jsdoc-type-pratt-parser": "~3.1.0"
             },
             "engines": {
-                "node": "^14 || ^16 || ^17 || ^18"
+                "node": "^14 || ^16 || ^17 || ^18 || ^19"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.1.2.tgz",
+            "integrity": "sha512-7qELuQWWjVDdVsFQ5+beUl+KPczrEDA7S3zM4QUd/bJl7oXgsmpXaEVqrRTnOBqenOV4rWf2kVZk2Ot085zPWA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-            "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+            "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.3.2",
-                "globals": "^13.15.0",
+                "espree": "^9.4.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -367,6 +381,9 @@
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/argparse": {
@@ -385,18 +402,6 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/@gulp-sourcemaps/identity-map": {
@@ -502,17 +507,30 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+            "version": "0.11.8",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "minimatch": "^3.0.5"
             },
             "engines": {
                 "node": ">=10.10.0"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
@@ -674,9 +692,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.11.43",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
-            "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ==",
+            "version": "18.11.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -691,18 +709,24 @@
             "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
             "dev": true
         },
+        "node_modules/@types/semver": {
+            "version": "7.3.13",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "dev": true
+        },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.5.tgz",
-            "integrity": "sha512-lftkqRoBvc28VFXEoRgyZuztyVUQ04JvUnATSPtIRFAccbXTWL6DEtXGYMcbg998kXw1NLUJm7rTQ9eUt+q6Ig==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz",
+            "integrity": "sha512-SVLafp0NXpoJY7ut6VFVUU9I+YeFsDzeQwtK0WZ+xbRN3mtxJ08je+6Oi2N89qDn087COdO0u3blKZNv9VetRQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.30.5",
-                "@typescript-eslint/type-utils": "5.30.5",
-                "@typescript-eslint/utils": "5.30.5",
+                "@typescript-eslint/scope-manager": "5.48.0",
+                "@typescript-eslint/type-utils": "5.48.0",
+                "@typescript-eslint/utils": "5.48.0",
                 "debug": "^4.3.4",
-                "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.2.0",
+                "natural-compare-lite": "^1.4.0",
                 "regexpp": "^3.2.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
@@ -725,12 +749,12 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin-tslint": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.30.5.tgz",
-            "integrity": "sha512-18sUCEAxs7G0MqrFLOT1K8eQtZfe1WkL9zuSDT8lb19EtNWYxiv29anEY7EZoe+6vPNBr0FYHVuyHJjZu37DLA==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.48.0.tgz",
+            "integrity": "sha512-4MB31eql6SIKYzCfn/hV37IYPuSGDG0+Sfsc4fT3JnPh2ynCd8rfsMI4LSI55FGqcinUe6Aj3On/svedrvdawA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/utils": "5.30.5",
+                "@typescript-eslint/utils": "5.48.0",
                 "lodash": "^4.17.21"
             },
             "engines": {
@@ -743,14 +767,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.30.5.tgz",
-            "integrity": "sha512-zj251pcPXI8GO9NDKWWmygP6+UjwWmrdf9qMW/L/uQJBM/0XbU2inxe5io/234y/RCvwpKEYjZ6c1YrXERkK4Q==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
+            "integrity": "sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.30.5",
-                "@typescript-eslint/types": "5.30.5",
-                "@typescript-eslint/typescript-estree": "5.30.5",
+                "@typescript-eslint/scope-manager": "5.48.0",
+                "@typescript-eslint/types": "5.48.0",
+                "@typescript-eslint/typescript-estree": "5.48.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -770,13 +794,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.5.tgz",
-            "integrity": "sha512-NJ6F+YHHFT/30isRe2UTmIGGAiXKckCyMnIV58cE3JkHmaD6e5zyEYm5hBDv0Wbin+IC0T1FWJpD3YqHUG/Ydg==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz",
+            "integrity": "sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.30.5",
-                "@typescript-eslint/visitor-keys": "5.30.5"
+                "@typescript-eslint/types": "5.48.0",
+                "@typescript-eslint/visitor-keys": "5.48.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -787,12 +811,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.5.tgz",
-            "integrity": "sha512-k9+ejlv1GgwN1nN7XjVtyCgE0BTzhzT1YsQF0rv4Vfj2U9xnslBgMYYvcEYAFVdvhuEscELJsB7lDkN7WusErw==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
+            "integrity": "sha512-vbtPO5sJyFjtHkGlGK4Sthmta0Bbls4Onv0bEqOGm7hP9h8UpRsHJwsrCiWtCUndTRNQO/qe6Ijz9rnT/DB+7g==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/utils": "5.30.5",
+                "@typescript-eslint/typescript-estree": "5.48.0",
+                "@typescript-eslint/utils": "5.48.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -813,9 +838,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.5.tgz",
-            "integrity": "sha512-kZ80w/M2AvsbRvOr3PjaNh6qEW1LFqs2pLdo2s5R38B2HYXG8Z0PP48/4+j1QHJFL3ssHIbJ4odPRS8PlHrFfw==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.0.tgz",
+            "integrity": "sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -826,13 +851,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.5.tgz",
-            "integrity": "sha512-qGTc7QZC801kbYjAr4AgdOfnokpwStqyhSbiQvqGBLixniAKyH+ib2qXIVo4P9NgGzwyfD9I0nlJN7D91E1VpQ==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz",
+            "integrity": "sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.30.5",
-                "@typescript-eslint/visitor-keys": "5.30.5",
+                "@typescript-eslint/types": "5.48.0",
+                "@typescript-eslint/visitor-keys": "5.48.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -853,17 +878,19 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.30.5.tgz",
-            "integrity": "sha512-o4SSUH9IkuA7AYIfAvatldovurqTAHrfzPApOZvdUq01hHojZojCFXx06D/aFpKCgWbMPRdJBWAC3sWp3itwTA==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.0.tgz",
+            "integrity": "sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==",
             "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.30.5",
-                "@typescript-eslint/types": "5.30.5",
-                "@typescript-eslint/typescript-estree": "5.30.5",
+                "@types/semver": "^7.3.12",
+                "@typescript-eslint/scope-manager": "5.48.0",
+                "@typescript-eslint/types": "5.48.0",
+                "@typescript-eslint/typescript-estree": "5.48.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0"
+                "eslint-utils": "^3.0.0",
+                "semver": "^7.3.7"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -877,12 +904,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.5.tgz",
-            "integrity": "sha512-D+xtGo9HUMELzWIUqcQc0p2PO4NyvTrgIOK/VnSH083+8sq0tiLozNRKuLarwHYGRuA6TVBQSuuLwJUDWd3aaA==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz",
+            "integrity": "sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.30.5",
+                "@typescript-eslint/types": "5.48.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -900,9 +927,9 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.7.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -1547,10 +1574,19 @@
             }
         },
         "node_modules/ci-info": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-            "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
-            "dev": true
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+            "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/class-utils": {
             "version": "0.3.6",
@@ -2426,13 +2462,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.19.0.tgz",
-            "integrity": "sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==",
+            "version": "8.31.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
+            "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.3.0",
-                "@humanwhocodes/config-array": "^0.9.2",
+                "@eslint/eslintrc": "^1.4.1",
+                "@humanwhocodes/config-array": "^0.11.8",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -2442,18 +2480,21 @@
                 "eslint-scope": "^7.1.1",
                 "eslint-utils": "^3.0.0",
                 "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.2",
+                "espree": "^9.4.0",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.15.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "globals": "^13.19.0",
+                "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
+                "is-path-inside": "^3.0.3",
+                "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
@@ -2464,8 +2505,7 @@
                 "regexpp": "^3.2.0",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
+                "text-table": "^0.2.0"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
@@ -2478,9 +2518,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+            "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -2645,18 +2685,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/eslint-plugin-import/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/eslint-plugin-import/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2664,21 +2692,21 @@
             "dev": true
         },
         "node_modules/eslint-plugin-jsdoc": {
-            "version": "39.3.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.3.tgz",
-            "integrity": "sha512-K/DAjKRUNaUTf0KQhI9PvsF+Y3mGDx/j0pofXsJCQe/tmRsRweBIXR353c8nAro0lytZYEf7l0PluBpzKDiHxw==",
+            "version": "39.6.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
+            "integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
             "dev": true,
             "dependencies": {
-                "@es-joy/jsdoccomment": "~0.31.0",
+                "@es-joy/jsdoccomment": "~0.36.1",
                 "comment-parser": "1.3.1",
                 "debug": "^4.3.4",
                 "escape-string-regexp": "^4.0.0",
                 "esquery": "^1.4.0",
-                "semver": "^7.3.7",
+                "semver": "^7.3.8",
                 "spdx-expression-parse": "^3.0.1"
             },
             "engines": {
-                "node": "^14 || ^16 || ^17 || ^18"
+                "node": "^14 || ^16 || ^17 || ^18 || ^19"
             },
             "peerDependencies": {
                 "eslint": "^7.0.0 || ^8.0.0"
@@ -2726,47 +2754,49 @@
                 }
             }
         },
-        "node_modules/eslint-plugin-react-hooks": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-            }
-        },
         "node_modules/eslint-plugin-unicorn": {
-            "version": "42.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz",
-            "integrity": "sha512-ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==",
+            "version": "45.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.2.tgz",
+            "integrity": "sha512-Y0WUDXRyGDMcKLiwgL3zSMpHrXI00xmdyixEGIg90gHnj0PcHY4moNv3Ppje/kDivdAy5vUeUr7z211ImPv2gw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.15.7",
-                "ci-info": "^3.3.0",
+                "@babel/helper-validator-identifier": "^7.19.1",
+                "@eslint-community/eslint-utils": "^4.1.2",
+                "ci-info": "^3.6.1",
                 "clean-regexp": "^1.0.0",
-                "eslint-utils": "^3.0.0",
                 "esquery": "^1.4.0",
                 "indent-string": "^4.0.0",
-                "is-builtin-module": "^3.1.0",
+                "is-builtin-module": "^3.2.0",
+                "jsesc": "^3.0.2",
                 "lodash": "^4.17.21",
                 "pluralize": "^8.0.0",
                 "read-pkg-up": "^7.0.1",
                 "regexp-tree": "^0.1.24",
+                "regjsparser": "^0.9.1",
                 "safe-regex": "^2.1.1",
-                "semver": "^7.3.5",
+                "semver": "^7.3.8",
                 "strip-indent": "^3.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14.18"
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
             },
             "peerDependencies": {
-                "eslint": ">=8.8.0"
+                "eslint": ">=8.28.0"
+            }
+        },
+        "node_modules/eslint-plugin-unicorn/node_modules/jsesc": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "dev": true,
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/eslint-scope": {
@@ -2858,6 +2888,22 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/eslint/node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/eslint/node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2882,30 +2928,66 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+        "node_modules/eslint/node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "p-locate": "^5.0.0"
             },
             "engines": {
-                "node": "*"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/espree": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-            "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.7.1",
+                "acorn": "^8.8.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/esprima": {
@@ -3245,9 +3327,9 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+            "version": "3.2.12",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -3273,9 +3355,9 @@
             "dev": true
         },
         "node_modules/fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -3730,12 +3812,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
@@ -4257,9 +4333,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.16.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.16.0.tgz",
-            "integrity": "sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==",
+            "version": "13.19.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+            "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -4319,6 +4395,12 @@
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
+        },
+        "node_modules/grapheme-splitter": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
             "dev": true
         },
         "node_modules/gulp": {
@@ -4968,9 +5050,9 @@
             }
         },
         "node_modules/import-fresh": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-            "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
@@ -4978,6 +5060,9 @@
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/imurmurhash": {
@@ -5141,15 +5226,18 @@
             "dev": true
         },
         "node_modules/is-builtin-module": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
-            "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+            "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
             "dev": true,
             "dependencies": {
-                "builtin-modules": "^3.0.0"
+                "builtin-modules": "^3.3.0"
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-callable": {
@@ -5331,6 +5419,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
@@ -5655,6 +5752,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/js-sdsl": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+            "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+            "dev": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/js-sdsl"
             }
         },
         "node_modules/js-tokens": {
@@ -6511,9 +6618,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-            "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -6886,6 +6993,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "node_modules/natural-compare-lite": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
         },
         "node_modules/next-tick": {
@@ -7680,9 +7793,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
+            "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -8039,6 +8152,27 @@
                 "url": "https://github.com/sponsors/mysticatea"
             }
         },
+        "node_modules/regjsparser": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+            "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+            "dev": true,
+            "dependencies": {
+                "jsesc": "~0.5.0"
+            },
+            "bin": {
+                "regjsparser": "bin/parser"
+            }
+        },
+        "node_modules/regjsparser/node_modules/jsesc": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+            "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+            "dev": true,
+            "bin": {
+                "jsesc": "bin/jsesc"
+            }
+        },
         "node_modules/release-zalgo": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -8220,7 +8354,7 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "engines": {
-                "node": ">=8"
+                "node": ">=4"
             }
         },
         "node_modules/resolve-options": {
@@ -8338,9 +8472,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -9590,9 +9724,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -9798,12 +9932,6 @@
             "bin": {
                 "uuid": "bin/uuid"
             }
-        },
-        "node_modules/v8-compile-cache": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
-            "dev": true
         },
         "node_modules/v8flags": {
             "version": "3.2.0",
@@ -10364,9 +10492,9 @@
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-            "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+            "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
             "dev": true
         },
         "@babel/helpers": {
@@ -10491,9 +10619,9 @@
             }
         },
         "@es-joy/jsdoccomment": {
-            "version": "0.31.0",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz",
-            "integrity": "sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==",
+            "version": "0.36.1",
+            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+            "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
             "dev": true,
             "requires": {
                 "comment-parser": "1.3.1",
@@ -10501,16 +10629,25 @@
                 "jsdoc-type-pratt-parser": "~3.1.0"
             }
         },
+        "@eslint-community/eslint-utils": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.1.2.tgz",
+            "integrity": "sha512-7qELuQWWjVDdVsFQ5+beUl+KPczrEDA7S3zM4QUd/bJl7oXgsmpXaEVqrRTnOBqenOV4rWf2kVZk2Ot085zPWA==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^3.3.0"
+            }
+        },
         "@eslint/eslintrc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-            "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+            "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.3.2",
-                "globals": "^13.15.0",
+                "espree": "^9.4.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -10531,15 +10668,6 @@
                     "dev": true,
                     "requires": {
                         "argparse": "^2.0.1"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
                     }
                 }
             }
@@ -10633,15 +10761,21 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+            "version": "0.11.8",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "minimatch": "^3.0.5"
             }
+        },
+        "@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true
         },
         "@humanwhocodes/object-schema": {
             "version": "1.2.1",
@@ -10786,9 +10920,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "16.11.43",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
-            "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ==",
+            "version": "18.11.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -10803,80 +10937,87 @@
             "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
             "dev": true
         },
+        "@types/semver": {
+            "version": "7.3.13",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "dev": true
+        },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.5.tgz",
-            "integrity": "sha512-lftkqRoBvc28VFXEoRgyZuztyVUQ04JvUnATSPtIRFAccbXTWL6DEtXGYMcbg998kXw1NLUJm7rTQ9eUt+q6Ig==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz",
+            "integrity": "sha512-SVLafp0NXpoJY7ut6VFVUU9I+YeFsDzeQwtK0WZ+xbRN3mtxJ08je+6Oi2N89qDn087COdO0u3blKZNv9VetRQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.30.5",
-                "@typescript-eslint/type-utils": "5.30.5",
-                "@typescript-eslint/utils": "5.30.5",
+                "@typescript-eslint/scope-manager": "5.48.0",
+                "@typescript-eslint/type-utils": "5.48.0",
+                "@typescript-eslint/utils": "5.48.0",
                 "debug": "^4.3.4",
-                "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.2.0",
+                "natural-compare-lite": "^1.4.0",
                 "regexpp": "^3.2.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/eslint-plugin-tslint": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.30.5.tgz",
-            "integrity": "sha512-18sUCEAxs7G0MqrFLOT1K8eQtZfe1WkL9zuSDT8lb19EtNWYxiv29anEY7EZoe+6vPNBr0FYHVuyHJjZu37DLA==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.48.0.tgz",
+            "integrity": "sha512-4MB31eql6SIKYzCfn/hV37IYPuSGDG0+Sfsc4fT3JnPh2ynCd8rfsMI4LSI55FGqcinUe6Aj3On/svedrvdawA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.30.5",
+                "@typescript-eslint/utils": "5.48.0",
                 "lodash": "^4.17.21"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.30.5.tgz",
-            "integrity": "sha512-zj251pcPXI8GO9NDKWWmygP6+UjwWmrdf9qMW/L/uQJBM/0XbU2inxe5io/234y/RCvwpKEYjZ6c1YrXERkK4Q==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
+            "integrity": "sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.30.5",
-                "@typescript-eslint/types": "5.30.5",
-                "@typescript-eslint/typescript-estree": "5.30.5",
+                "@typescript-eslint/scope-manager": "5.48.0",
+                "@typescript-eslint/types": "5.48.0",
+                "@typescript-eslint/typescript-estree": "5.48.0",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.5.tgz",
-            "integrity": "sha512-NJ6F+YHHFT/30isRe2UTmIGGAiXKckCyMnIV58cE3JkHmaD6e5zyEYm5hBDv0Wbin+IC0T1FWJpD3YqHUG/Ydg==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz",
+            "integrity": "sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.30.5",
-                "@typescript-eslint/visitor-keys": "5.30.5"
+                "@typescript-eslint/types": "5.48.0",
+                "@typescript-eslint/visitor-keys": "5.48.0"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.5.tgz",
-            "integrity": "sha512-k9+ejlv1GgwN1nN7XjVtyCgE0BTzhzT1YsQF0rv4Vfj2U9xnslBgMYYvcEYAFVdvhuEscELJsB7lDkN7WusErw==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
+            "integrity": "sha512-vbtPO5sJyFjtHkGlGK4Sthmta0Bbls4Onv0bEqOGm7hP9h8UpRsHJwsrCiWtCUndTRNQO/qe6Ijz9rnT/DB+7g==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.30.5",
+                "@typescript-eslint/typescript-estree": "5.48.0",
+                "@typescript-eslint/utils": "5.48.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.5.tgz",
-            "integrity": "sha512-kZ80w/M2AvsbRvOr3PjaNh6qEW1LFqs2pLdo2s5R38B2HYXG8Z0PP48/4+j1QHJFL3ssHIbJ4odPRS8PlHrFfw==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.0.tgz",
+            "integrity": "sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.5.tgz",
-            "integrity": "sha512-qGTc7QZC801kbYjAr4AgdOfnokpwStqyhSbiQvqGBLixniAKyH+ib2qXIVo4P9NgGzwyfD9I0nlJN7D91E1VpQ==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz",
+            "integrity": "sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.30.5",
-                "@typescript-eslint/visitor-keys": "5.30.5",
+                "@typescript-eslint/types": "5.48.0",
+                "@typescript-eslint/visitor-keys": "5.48.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -10885,26 +11026,28 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.30.5.tgz",
-            "integrity": "sha512-o4SSUH9IkuA7AYIfAvatldovurqTAHrfzPApOZvdUq01hHojZojCFXx06D/aFpKCgWbMPRdJBWAC3sWp3itwTA==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.0.tgz",
+            "integrity": "sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.30.5",
-                "@typescript-eslint/types": "5.30.5",
-                "@typescript-eslint/typescript-estree": "5.30.5",
+                "@types/semver": "^7.3.12",
+                "@typescript-eslint/scope-manager": "5.48.0",
+                "@typescript-eslint/types": "5.48.0",
+                "@typescript-eslint/typescript-estree": "5.48.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0"
+                "eslint-utils": "^3.0.0",
+                "semver": "^7.3.7"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.30.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.5.tgz",
-            "integrity": "sha512-D+xtGo9HUMELzWIUqcQc0p2PO4NyvTrgIOK/VnSH083+8sq0tiLozNRKuLarwHYGRuA6TVBQSuuLwJUDWd3aaA==",
+            "version": "5.48.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz",
+            "integrity": "sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.30.5",
+                "@typescript-eslint/types": "5.48.0",
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
@@ -10915,9 +11058,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.7.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true
         },
         "acorn-jsx": {
@@ -11400,9 +11543,9 @@
             }
         },
         "ci-info": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-            "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+            "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
             "dev": true
         },
         "class-utils": {
@@ -12136,13 +12279,15 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.19.0.tgz",
-            "integrity": "sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==",
+            "version": "8.31.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
+            "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.3.0",
-                "@humanwhocodes/config-array": "^0.9.2",
+                "@eslint/eslintrc": "^1.4.1",
+                "@humanwhocodes/config-array": "^0.11.8",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -12152,18 +12297,21 @@
                 "eslint-scope": "^7.1.1",
                 "eslint-utils": "^3.0.0",
                 "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.2",
+                "espree": "^9.4.0",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.15.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "globals": "^13.19.0",
+                "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
+                "is-path-inside": "^3.0.3",
+                "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
@@ -12174,8 +12322,7 @@
                 "regexpp": "^3.2.0",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
+                "text-table": "^0.2.0"
             },
             "dependencies": {
                 "argparse": {
@@ -12206,6 +12353,16 @@
                     "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
                     "dev": true
                 },
+                "find-up": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^6.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
                 "glob-parent": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -12224,21 +12381,39 @@
                         "argparse": "^2.0.1"
                     }
                 },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                "locate-path": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "p-locate": "^5.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^3.0.2"
                     }
                 }
             }
         },
         "eslint-config-prettier": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+            "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
             "dev": true,
             "requires": {}
         },
@@ -12372,15 +12547,6 @@
                         "esutils": "^2.0.2"
                     }
                 },
-                "minimatch": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -12390,17 +12556,17 @@
             }
         },
         "eslint-plugin-jsdoc": {
-            "version": "39.3.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.3.tgz",
-            "integrity": "sha512-K/DAjKRUNaUTf0KQhI9PvsF+Y3mGDx/j0pofXsJCQe/tmRsRweBIXR353c8nAro0lytZYEf7l0PluBpzKDiHxw==",
+            "version": "39.6.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
+            "integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
             "dev": true,
             "requires": {
-                "@es-joy/jsdoccomment": "~0.31.0",
+                "@es-joy/jsdoccomment": "~0.36.1",
                 "comment-parser": "1.3.1",
                 "debug": "^4.3.4",
                 "escape-string-regexp": "^4.0.0",
                 "esquery": "^1.4.0",
-                "semver": "^7.3.7",
+                "semver": "^7.3.8",
                 "spdx-expression-parse": "^3.0.1"
             },
             "dependencies": {
@@ -12428,33 +12594,36 @@
                 "prettier-linter-helpers": "^1.0.0"
             }
         },
-        "eslint-plugin-react-hooks": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-            "dev": true,
-            "requires": {}
-        },
         "eslint-plugin-unicorn": {
-            "version": "42.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz",
-            "integrity": "sha512-ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==",
+            "version": "45.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.2.tgz",
+            "integrity": "sha512-Y0WUDXRyGDMcKLiwgL3zSMpHrXI00xmdyixEGIg90gHnj0PcHY4moNv3Ppje/kDivdAy5vUeUr7z211ImPv2gw==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.15.7",
-                "ci-info": "^3.3.0",
+                "@babel/helper-validator-identifier": "^7.19.1",
+                "@eslint-community/eslint-utils": "^4.1.2",
+                "ci-info": "^3.6.1",
                 "clean-regexp": "^1.0.0",
-                "eslint-utils": "^3.0.0",
                 "esquery": "^1.4.0",
                 "indent-string": "^4.0.0",
-                "is-builtin-module": "^3.1.0",
+                "is-builtin-module": "^3.2.0",
+                "jsesc": "^3.0.2",
                 "lodash": "^4.17.21",
                 "pluralize": "^8.0.0",
                 "read-pkg-up": "^7.0.1",
                 "regexp-tree": "^0.1.24",
+                "regjsparser": "^0.9.1",
                 "safe-regex": "^2.1.1",
-                "semver": "^7.3.5",
+                "semver": "^7.3.8",
                 "strip-indent": "^3.0.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+                    "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+                    "dev": true
+                }
             }
         },
         "eslint-scope": {
@@ -12491,12 +12660,12 @@
             "dev": true
         },
         "espree": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-            "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
             "dev": true,
             "requires": {
-                "acorn": "^8.7.1",
+                "acorn": "^8.8.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^3.3.0"
             }
@@ -12779,9 +12948,9 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+            "version": "3.2.12",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -12804,9 +12973,9 @@
             "dev": true
         },
         "fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
             "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
@@ -13194,12 +13363,6 @@
                 "es-abstract": "^1.19.0",
                 "functions-have-names": "^1.2.2"
             }
-        },
-        "functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true
         },
         "functions-have-names": {
             "version": "1.2.3",
@@ -13635,9 +13798,9 @@
             }
         },
         "globals": {
-            "version": "13.16.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.16.0.tgz",
-            "integrity": "sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==",
+            "version": "13.19.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+            "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -13678,6 +13841,12 @@
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
+        },
+        "grapheme-splitter": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
             "dev": true
         },
         "gulp": {
@@ -14203,9 +14372,9 @@
             "dev": true
         },
         "import-fresh": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-            "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
@@ -14336,12 +14505,12 @@
             "dev": true
         },
         "is-builtin-module": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
-            "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+            "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
             "dev": true,
             "requires": {
-                "builtin-modules": "^3.0.0"
+                "builtin-modules": "^3.3.0"
             }
         },
         "is-callable": {
@@ -14470,6 +14639,12 @@
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
+        },
+        "is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true
         },
         "is-plain-obj": {
             "version": "2.1.0",
@@ -14713,6 +14888,12 @@
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
             }
+        },
+        "js-sdsl": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+            "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -15414,9 +15595,9 @@
             "dev": true
         },
         "minimatch": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-            "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
@@ -15702,6 +15883,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "natural-compare-lite": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
         },
         "next-tick": {
@@ -16325,9 +16512,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
+            "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
             "dev": true
         },
         "prettier-eslint": {
@@ -16612,6 +16799,23 @@
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
             "dev": true
         },
+        "regjsparser": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+            "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+                    "dev": true
+                }
+            }
+        },
         "release-zalgo": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -16842,9 +17046,9 @@
             }
         },
         "semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"
@@ -17885,9 +18089,9 @@
             }
         },
         "typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true
         },
         "uc.micro": {
@@ -18052,12 +18256,6 @@
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "dev": true
-        },
-        "v8-compile-cache": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
             "dev": true
         },
         "v8flags": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gtp2ogs",
-    "version": "7.0.0-beta.1",
+    "version": "7.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gtp2ogs",
-            "version": "7.0.0-beta.1",
+            "version": "7.0.0",
             "license": "ISC",
             "dependencies": {
                 "socket.io-client": "^4.1.2",
@@ -32,6 +32,7 @@
                 "eslint-plugin-unicorn": "^42.0.0",
                 "gulp": "^4.0.2",
                 "gulp-eslint-new": "^1.4.4",
+                "gulp-sourcemaps": "^3.0.0",
                 "gulp-typescript": "^6.0.0-alpha.1",
                 "markdownlint": "^0.26.2",
                 "markdownlint-cli": "^0.32.2",
@@ -396,6 +397,108 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/@gulp-sourcemaps/identity-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
+            "integrity": "sha512-Tb+nSISZku+eQ4X1lAkevcQa+jknn/OVUgZ3XCxEKIsLsqYuPoJwJOPQeaOk75X3WPftb29GWY1eqE7GLsXb1Q==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^6.4.1",
+                "normalize-path": "^3.0.0",
+                "postcss": "^7.0.16",
+                "source-map": "^0.6.0",
+                "through2": "^3.0.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/@gulp-sourcemaps/identity-map/node_modules/acorn": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+            "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/@gulp-sourcemaps/identity-map/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@gulp-sourcemaps/map-sources": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+            "integrity": "sha512-o/EatdaGt8+x2qpb0vFLC/2Gug/xYPRXb6a+ET1wGYKozKN3krDWC/zZFZAtrzxJHuDL12mwdfEFKcKMNvc55A==",
+            "dev": true,
+            "dependencies": {
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/@gulp-sourcemaps/map-sources/node_modules/normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+            "dev": true,
+            "dependencies": {
+                "remove-trailing-separator": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@gulp-sourcemaps/map-sources/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/@gulp-sourcemaps/map-sources/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "node_modules/@gulp-sourcemaps/map-sources/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/@gulp-sourcemaps/map-sources/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -1852,6 +1955,37 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "source-map": "^0.6.1",
+                "source-map-resolve": "^0.6.0"
+            }
+        },
+        "node_modules/css/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/css/node_modules/source-map-resolve": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+            "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+            "dev": true,
+            "dependencies": {
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0"
+            }
+        },
         "node_modules/d": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -1884,6 +2018,26 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/debug-fabulous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+            "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
+            "dev": true,
+            "dependencies": {
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
+            }
+        },
+        "node_modules/debug-fabulous/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "^2.1.1"
             }
         },
         "node_modules/decamelize": {
@@ -1987,6 +2141,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
             "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/detect-newline": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2816,6 +2979,16 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+            "dev": true,
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "node_modules/expand-brackets": {
@@ -4457,6 +4630,89 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/gulp-sourcemaps": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-3.0.0.tgz",
+            "integrity": "sha512-RqvUckJkuYqy4VaIH60RMal4ZtG0IbQ6PXMNkNsshEGJ9cldUPRb/YCgboYae+CLAs1HQNb4ADTKCx65HInquQ==",
+            "dev": true,
+            "dependencies": {
+                "@gulp-sourcemaps/identity-map": "^2.0.1",
+                "@gulp-sourcemaps/map-sources": "^1.0.0",
+                "acorn": "^6.4.1",
+                "convert-source-map": "^1.0.0",
+                "css": "^3.0.0",
+                "debug-fabulous": "^1.0.0",
+                "detect-newline": "^2.0.0",
+                "graceful-fs": "^4.0.0",
+                "source-map": "^0.6.0",
+                "strip-bom-string": "^1.0.0",
+                "through2": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/gulp-sourcemaps/node_modules/acorn": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+            "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/gulp-sourcemaps/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/gulp-sourcemaps/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "node_modules/gulp-sourcemaps/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gulp-sourcemaps/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/gulp-sourcemaps/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
         "node_modules/gulp-typescript": {
             "version": "6.0.0-alpha.1",
             "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-6.0.0-alpha.1.tgz",
@@ -5094,6 +5350,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-promise": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+            "dev": true
         },
         "node_modules/is-regex": {
             "version": "1.1.4",
@@ -5811,6 +6073,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+            "dev": true,
+            "dependencies": {
+                "es5-ext": "~0.10.2"
+            }
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6185,6 +6456,22 @@
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
             "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
             "dev": true
+        },
+        "node_modules/memoizee": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+            "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+            "dev": true,
+            "dependencies": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.53",
+                "es6-weak-map": "^2.0.3",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.2.2",
+                "lru-queue": "^0.1.0",
+                "next-tick": "^1.1.0",
+                "timers-ext": "^0.1.7"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -6742,6 +7029,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -7243,6 +7539,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/picocolors": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+            "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+            "dev": true
+        },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -7337,6 +7639,32 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
             "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "7.0.39",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+            "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+            "dev": true,
+            "dependencies": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/postcss/"
+            }
+        },
+        "node_modules/postcss/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -8692,6 +9020,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-bom-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+            "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/strip-indent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -8849,6 +9186,16 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/timers-ext": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "dev": true,
+            "dependencies": {
+                "es5-ext": "~0.10.46",
+                "next-tick": "1"
             }
         },
         "node_modules/tinytim": {
@@ -10197,6 +10544,94 @@
                 }
             }
         },
+        "@gulp-sourcemaps/identity-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
+            "integrity": "sha512-Tb+nSISZku+eQ4X1lAkevcQa+jknn/OVUgZ3XCxEKIsLsqYuPoJwJOPQeaOk75X3WPftb29GWY1eqE7GLsXb1Q==",
+            "dev": true,
+            "requires": {
+                "acorn": "^6.4.1",
+                "normalize-path": "^3.0.0",
+                "postcss": "^7.0.16",
+                "source-map": "^0.6.0",
+                "through2": "^3.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.4.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+                    "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@gulp-sourcemaps/map-sources": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+            "integrity": "sha512-o/EatdaGt8+x2qpb0vFLC/2Gug/xYPRXb6a+ET1wGYKozKN3krDWC/zZFZAtrzxJHuDL12mwdfEFKcKMNvc55A==",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
+            }
+        },
         "@humanwhocodes/config-array": {
             "version": "0.9.5",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -11315,6 +11750,35 @@
                 "which": "^2.0.1"
             }
         },
+        "css": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.4",
+                "source-map": "^0.6.1",
+                "source-map-resolve": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-resolve": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+                    "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+                    "dev": true,
+                    "requires": {
+                        "atob": "^2.1.2",
+                        "decode-uri-component": "^0.2.0"
+                    }
+                }
+            }
+        },
         "d": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -11336,6 +11800,28 @@
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "requires": {
                 "ms": "2.1.2"
+            }
+        },
+        "debug-fabulous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+            "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
+            "dev": true,
+            "requires": {
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "decamelize": {
@@ -11412,6 +11898,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
             "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+            "dev": true
+        },
+        "detect-newline": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==",
             "dev": true
         },
         "diff": {
@@ -12060,6 +12552,16 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -13434,6 +13936,79 @@
                 }
             }
         },
+        "gulp-sourcemaps": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-3.0.0.tgz",
+            "integrity": "sha512-RqvUckJkuYqy4VaIH60RMal4ZtG0IbQ6PXMNkNsshEGJ9cldUPRb/YCgboYae+CLAs1HQNb4ADTKCx65HInquQ==",
+            "dev": true,
+            "requires": {
+                "@gulp-sourcemaps/identity-map": "^2.0.1",
+                "@gulp-sourcemaps/map-sources": "^1.0.0",
+                "acorn": "^6.4.1",
+                "convert-source-map": "^1.0.0",
+                "css": "^3.0.0",
+                "debug-fabulous": "^1.0.0",
+                "detect-newline": "^2.0.0",
+                "graceful-fs": "^4.0.0",
+                "source-map": "^0.6.0",
+                "strip-bom-string": "^1.0.0",
+                "through2": "^2.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.4.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+                    "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
+            }
+        },
         "gulp-typescript": {
             "version": "6.0.0-alpha.1",
             "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-6.0.0-alpha.1.tgz",
@@ -13906,6 +14481,12 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
             "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "dev": true
+        },
+        "is-promise": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
             "dev": true
         },
         "is-regex": {
@@ -14472,6 +15053,15 @@
                 "yallist": "^4.0.0"
             }
         },
+        "lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.2"
+            }
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -14778,6 +15368,22 @@
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
             "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
             "dev": true
+        },
+        "memoizee": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+            "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.53",
+                "es6-weak-map": "^2.0.3",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.2.2",
+                "lru-queue": "^0.1.0",
+                "next-tick": "^1.1.0",
+                "timers-ext": "^0.1.7"
+            }
         },
         "merge-stream": {
             "version": "2.0.0",
@@ -15216,6 +15822,12 @@
                 }
             }
         },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true
+        },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -15611,6 +16223,12 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
+        "picocolors": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+            "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+            "dev": true
+        },
         "picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -15681,6 +16299,24 @@
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
             "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
             "dev": true
+        },
+        "postcss": {
+            "version": "7.0.39",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+            "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+            "dev": true,
+            "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
         },
         "prelude-ls": {
             "version": "1.2.1",
@@ -16770,6 +17406,12 @@
             "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
             "dev": true
         },
+        "strip-bom-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+            "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+            "dev": true
+        },
         "strip-indent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -16906,6 +17548,16 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha512-gLCeArryy2yNTRzTGKbZbloctj64jkZ57hj5zdraXue6aFgd6PmvVtEyiUU+hvU0v7q08oVv8r8ev0tRo6bvgw==",
             "dev": true
+        },
+        "timers-ext": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.46",
+                "next-tick": "1"
+            }
         },
         "tinytim": {
             "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gtp2ogs",
-    "version": "7.0.0",
+    "version": "7.1.0-beta.1",
     "description": "Wrapper to allow Gnu Go Text Protocol speaking Go engines to connect to Online-Go.com and play games",
     "files": [
         "dist/*"
@@ -13,18 +13,17 @@
         "yargs": "^15.4.0"
     },
     "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.26.0",
-        "@typescript-eslint/eslint-plugin-tslint": "^5.26.0",
-        "@typescript-eslint/parser": "^5.26.0",
-        "@types/node": "^16.11.6",
-        "eslint": "^8.16.0",
-        "eslint-config-prettier": "^8.5.0",
+        "@typescript-eslint/eslint-plugin": "^5.48.0",
+        "@typescript-eslint/eslint-plugin-tslint": "^5.48.0",
+        "@typescript-eslint/parser": "^5.48.0",
+        "@types/node": "^18.11.18",
+        "eslint": "^8.31.0",
+        "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-jsdoc": "^39.3.1",
+        "eslint-plugin-jsdoc": "^39.6.4",
         "eslint-plugin-prefer-arrow": "^1.2.3",
-        "eslint-plugin-prettier": "^4.0.0",
-        "eslint-plugin-react-hooks": "^4.5.0",
-        "eslint-plugin-unicorn": "^42.0.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-unicorn": "^45.0.2",
         "markdownlint": "^0.26.2",
         "markdownlint-cli": "^0.32.2",
         "mocha": "^10.0.0",
@@ -33,9 +32,9 @@
         "gulp-sourcemaps": "^3.0.0",
         "gulp-typescript": "^6.0.0-alpha.1",
         "nyc": "^15.0.1",
-        "prettier": "2.6.2",
-        "prettier-eslint": "^15.0.0",
-        "typescript": "^4.7.2",
+        "prettier": "2.8.2",
+        "prettier-eslint": "^15.0.1",
+        "typescript": "^4.9.4",
         "sinon": "^9.0.2"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gtp2ogs",
-    "version": "7.0.0-beta.1",
+    "version": "7.0.0",
     "description": "Wrapper to allow Gnu Go Text Protocol speaking Go engines to connect to Online-Go.com and play games",
     "files": [
         "dist/*"
@@ -30,6 +30,7 @@
         "mocha": "^10.0.0",
         "gulp": "^4.0.2",
         "gulp-eslint-new": "^1.4.4",
+        "gulp-sourcemaps": "^3.0.0",
         "gulp-typescript": "^6.0.0-alpha.1",
         "nyc": "^15.0.1",
         "prettier": "2.6.2",

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -35,13 +35,15 @@ export class Bot {
     katafischer: boolean;
     katatime: boolean;
     json_initialized: boolean;
+    is_resign_bot: boolean;
 
-    constructor(conn: Connection, game: Game, cmd: string[]) {
+    constructor(conn: Connection, game: Game, cmd: string[], is_resign_bot: boolean = false) {
         this.conn = conn;
         this.game = game;
         this.commands_sent = 0;
         this.command_callbacks = [];
         this.command_error_callbacks = [];
+        this.is_resign_bot = is_resign_bot;
         this.firstmove = true;
         this.ignore = false; // Ignore output from bot ?
         // Set to true when the bot process has died and needs to be restarted before it can be used again.
@@ -182,23 +184,32 @@ export class Bot {
             }
         });
     }
-    pid() {
+    pid(): number {
         if (this.proc) {
             return this.proc.pid;
         } else {
             return -1;
         }
     }
-    log(...arr: any[]) {
-        trace.log.apply(null, [`[${this.pid()}]`, ...arr]);
+    log(...arr: any[]): void {
+        trace.log.apply(null, [
+            `[${this.is_resign_bot ? "resign bot " : ""}${this.pid()}]`,
+            ...arr,
+        ]);
     }
-    error(...arr: any[]) {
-        trace.error.apply(null, [`[${this.pid()}]`, ...arr]);
+    error(...arr: any[]): void {
+        trace.error.apply(null, [
+            `[${this.is_resign_bot ? "resign bot " : ""}${this.pid()}]`,
+            ...arr,
+        ]);
     }
-    verbose(...arr: any[]) {
-        trace.verbose.apply(null, [`[${this.pid()}]`, ...arr]);
+    verbose(...arr: any[]): void {
+        trace.verbose.apply(null, [
+            `[${this.is_resign_bot ? "resign bot " : ""}${this.pid()}]`,
+            ...arr,
+        ]);
     }
-    loadClock(state) {
+    loadClock(state): void {
         /* References:
            http://www.lysator.liu.se/~gunnar/gtp/gtp2-spec-draft2/gtp2-spec.html#sec:time-handling
            http://www.weddslist.com/kgs/how/kgsGtp.html

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -21,21 +21,19 @@ export class Bot {
     conn: Connection;
     game: Game;
 
-    // TODO: these all need proper typings, these are just copy/paste from
-    // errors to get the typescript migration building
-    commands_sent: any;
-    command_callbacks: any;
-    command_error_callbacks: any;
-    firstmove: any;
-    ignore: any;
-    dead: any;
-    failed: any;
-    pv: any;
-    proc: any;
-    kgstime: any;
-    katafischer: any;
-    katatime: any;
-    json_initialized: any;
+    commands_sent: number;
+    command_callbacks: Array<cb_type>;
+    command_error_callbacks: Array<eb_type>;
+    firstmove: boolean;
+    ignore: boolean;
+    dead: boolean;
+    failed: boolean;
+    pv: Pv;
+    proc: ReturnType<typeof spawn>;
+    kgstime: boolean;
+    katafischer: boolean;
+    katatime: boolean;
+    json_initialized: boolean;
 
     constructor(conn: Connection, game: Game, cmd: string[]) {
         this.conn = conn;
@@ -150,7 +148,7 @@ export class Bot {
                     this.command_callbacks.shift();
                     const eb = this.command_error_callbacks.shift();
                     if (eb) {
-                        eb();
+                        eb(line.trim());
                     }
                     //throw new Error(`Unexpected output: ${line}`);
                 }

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -28,17 +28,17 @@ export class Connection {
     connected_games: { [game_id: string]: Game };
 
     socket: any;
-    games_by_player: any;
-    connected: any;
-    connect_timeout: any;
-    idle_timeout_interval: any;
-    clock_drift: any;
-    network_latency: any;
-    ping_interval: any;
+    games_by_player: { [player_id: string]: Game[] };
+    connected: boolean;
+    connect_timeout: ReturnType<typeof setTimeout>;
+    idle_timeout_interval: ReturnType<typeof setInterval>;
+    clock_drift: number;
+    network_latency: number;
+    ping_interval: ReturnType<typeof setInterval>;
     jwt: any;
-    bot_id: any;
-    corr_queue_interval: any;
-    corr_moves_processing: any;
+    bot_id: number;
+    corr_queue_interval: ReturnType<typeof setInterval>;
+    corr_moves_processing: number;
 
     constructor(io_client, myConfig) {
         config = myConfig;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -2,6 +2,7 @@ import { decodeMoves, move2gtpvertex } from "./gtp";
 
 import { Bot } from "./Bot";
 import { trace } from "./trace";
+import type { Connection } from "./Connection";
 let config;
 
 /**********/
@@ -13,20 +14,20 @@ export class Game {
 
     connect_timeout: ReturnType<typeof setTimeout>;
 
-    conn: any;
-    game_id: any;
+    conn: Connection;
+    game_id: number;
     socket: any;
     state: any;
-    opponent_evenodd: any;
-    greeted: any;
-    connected: any;
-    bot: any;
-    bot_failures: any;
-    my_color: any;
-    corr_move_pending: any;
-    processing: any;
-    handicap_moves: any;
-    disconnect_timeout: any;
+    opponent_evenodd: null | number;
+    greeted: boolean;
+    connected: boolean;
+    bot?: Bot;
+    bot_failures: number;
+    my_color: null | string;
+    corr_move_pending: boolean;
+    processing: boolean;
+    handicap_moves: Array<string>;
+    disconnect_timeout: ReturnType<typeof setTimeout>;
 
     constructor(conn, game_id, myConfig) {
         this.conn = conn;
@@ -37,7 +38,7 @@ export class Game {
         this.opponent_evenodd = null;
         this.greeted = false;
         this.connected = true;
-        this.bot = null;
+        this.bot = undefined;
         this.bot_failures = 0;
         this.my_color = null;
         this.corr_move_pending = false;
@@ -365,7 +366,7 @@ export class Game {
                 }
             }
             this.bot.kill();
-            this.bot = null;
+            this.bot = undefined;
         }
     }
     // Start the bot.
@@ -755,7 +756,7 @@ export class Game {
             "game/chat",
             this.auth({
                 game_id: this.game_id,
-                player_id: this.conn.user_id,
+                player_id: this.conn.bot_id,
                 body: str,
                 move_number: move_number,
                 type: type,

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,9 @@ export function updateFromArgv(argv) {
 
     const debugStatus = argv.debug ? "DEBUG: ON\n" : "";
     trace.log(
-        `\ngtp2ogs version 6.0.1\n--------------------\n- For changelog or latest devel updates, please visit https://github.com/online-go/gtp2ogs/tree/devel\n${debugStatus}`,
+        `\ngtp2ogs version ${
+            process.env.npm_package_version || "development"
+        }\n--------------------\n- For changelog or latest devel updates, please visit https://github.com/online-go/gtp2ogs/tree/devel\n${debugStatus}`,
     );
 
     config.min_move_time = argv.minMoveTime || 0;
@@ -72,6 +74,21 @@ export function updateFromArgv(argv) {
         config.hidden = true;
     }
     config.bot_command = argv._;
+
+    if (argv.resignbot) {
+        /* Our full resign bot command needs to be encapsulated in qoutes as
+         * it's a shell command to run, this splits that command into an array
+         * like we normally expect for a bot command. Note while this does handle
+         * one level of qoutes, it doesn't handle qoute escaping or any other
+         * fancy stuff, so I appologize in advance if you bump into that.
+         * Here is the place to address that though if you need it.
+         */
+        const cmd = argv.resignbot
+            .split(/'(.*?)'|"(.*?)"|\s/)
+            .filter((x: string) => x !== undefined && x !== "");
+
+        config.resign_bot_command = cmd;
+    }
 
     // 2) specific ranked/unranked options exports
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -101,7 +101,12 @@ export const rankedUnrankedOptions = [
     { name: "maxperiodtimecorr", default: 259200 }, // 3 days
 ];
 
-export const config: { [key: string]: any } = {};
+interface Config {
+    bot_command: string[];
+    [key: string]: any;
+}
+
+export const config: Partial<Config> = {};
 
 function getBLCString(optionName: string, rankedUnranked: string): string {
     return `${optionName}blitz${rankedUnranked}, --${optionName}live${rankedUnranked} and/or --${optionName}corr${rankedUnranked}`;

--- a/src/getArgv.ts
+++ b/src/getArgv.ts
@@ -12,6 +12,10 @@ export function getArgv() {
         .describe("username", "Specify the username of the bot, for example GnuGo")
         .describe("apikey", "Specify the API key for the bot")
         .describe(
+            "resignbot",
+            "Specify an alternative bot command to run and consult for every move. If this bot at anypoint indicates that we should resign, we resign instead of playing our primary bot's move.",
+        )
+        .describe(
             "minMoveTime",
             "Specify the minimum move time in milliseconds. Bots that move faster than this will have an artificial delay added before submitting the move to slow the game down.",
         )

--- a/src/gtp2ogs.ts
+++ b/src/gtp2ogs.ts
@@ -16,9 +16,9 @@ import { trace } from "./trace";
 import { io } from "socket.io-client";
 import { Connection } from "./Connection";
 
-process.on("uncaughtException", (er) => {
+process.on("uncaughtException", (err) => {
     console.trace("ERROR: Uncaught exception");
-    trace.error(`ERROR: ${er.stack}`);
+    trace.error(err);
     if (!conn || !conn.socket) {
         conn = getNewConnection();
     } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,7 @@
+export interface Move {
+    x?: number;
+    y?: number;
+    text?: string;
+    resign?: boolean;
+    pass?: boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
         "noUnusedLocals": false,
 
         "sourceMap": true,
-        "inlineSources": true
+        "inlineSources": false
     },
     "exclude": ["node_modules"],
     "include": ["./src/**/*.ts"]


### PR DESCRIPTION
This PR adds support for a new flag `--resignbot "<cmd> <args>"`, which when specified will start up a second bot command to consult for each move, if the resulting move is a resignation, the bot will resign.

The goal of this is to allow weak bots, who sometimes have trouble realizing they should resign, to use a second presumably much stronger bot to handle resigning in a timely manner.

This PR also contains some non functional refactoring to switch from callback to async style processing in much of our bot and game code, which made adding this feature notably easier and reduces the overall complexity of the code base.
