### PR TITLE
Updated katago pv

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -163,7 +163,9 @@ export class Bot extends EventEmitter<Events> {
             this.log(`${errline}`);
 
             if (this.pv_parser) {
-                this.pv_parser.scanAndSendEngineAnalysis(this.game, errline);
+                if (this.pv_parser.scanAndSendEngineAnalysis(this.game, errline)) {
+                    return;
+                }
             }
             if (this.bot_config.send_chats) {
                 const chat_match = /(DISCUSSION|MALKOVICH|MAIN):(.*)/.exec(errline);

--- a/src/PvOutputParser.ts
+++ b/src/PvOutputParser.ts
@@ -28,14 +28,14 @@ export class PvOutputParser {
     }
 
     /** Scans the bot output for PVs and posts them to the chat. */
-    public scanAndSendEngineAnalysis(game: Game | undefined, line: string): void {
+    public scanAndSendEngineAnalysis(game: Game | undefined, line: string) {
         this.game = game;
         const engine = this.detected_engine;
         this.detectEngine(line);
         if (this.detected_engine !== engine) {
             trace.info("Detected engine: " + this.detected_engine);
         }
-        this.processLine(line);
+        return this.processLine(line);
     }
 
     private checkPondering(): boolean {
@@ -139,15 +139,15 @@ export class PvOutputParser {
             case "katago":
                 {
                     const match = line.match(
-                        /CHAT:Visits (\d*) Winrate (\d+\.\d\d)% ScoreLead (-?\d+\.\d) ScoreStdev (-?\d+\.\d) (\(PDA (-?\d+.\d\d)\) )?PV (.*)/,
+                        /(CHAT|MALKOVICH):Visits (\d*) Winrate (\d+\.\d\d)% ScoreLead (-?\d+\.\d) ScoreStdev (-?\d+\.\d) (\(PDA (-?\d+.\d\d)\) )?PV (.*)/,
                     );
                     if (match) {
                         this.lookingForPv = false;
-                        const visits = match[1];
-                        const win_rate = parseFloat(match[2]).toFixed(1);
-                        const scoreLead = match[3];
-                        const PDA = match[6] ? ` PDA: ${match[6]}` : "";
-                        const pv = this.formatMove(match[7]);
+                        const visits = match[2];
+                        const win_rate = parseFloat(match[3]).toFixed(1);
+                        const scoreLead = match[4];
+                        const PDA = match[6] ? ` PDA: ${match[7]}` : "";
+                        const pv = this.formatMove(match[8]);
                         const name = `Win rate: ${win_rate}%, Score: ${scoreLead}${PDA}, Visits: ${visits}`;
 
                         message = this.createAnalysisMessage(name, pv, {
@@ -345,7 +345,9 @@ export class PvOutputParser {
 
         if (message) {
             this.game?.sendChat(message, (this.game?.state.moves.length || 0) + 1, "malkovich");
+            return true;
         }
+        return false;
     }
 }
 


### PR DESCRIPTION
Katago recently updated the pv message from `CHAT:` to `MALKOVICH:`. This result in the pv output no longer working, breaking the preview analyses line.

[See 2b1e54a3 ("Update OGS chat to use malkovich prefix and update GTP docs a little", 2023-05-16)](https://github.com/lightvector/KataGo/commit/2b1e54a30385c99237a5cb20e29dc0065b93f84d#diff-bd67f2c1c385d731233befc2b93c3ad19de564e35748f56424a5eef445e6d829L1070-R1070)