### PR TITLE
Fix ending_bot crash

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -278,15 +278,17 @@ export class Game extends EventEmitter<Events> {
                                 decodeMoves(move.move, this.state.width, this.state.height)[0],
                                 this.state.width,
                                 this.state.height,
-                                this.my_color === "black" ? "white" : "black",
+                                "black", // we are white so we are recording black's moves
                             ),
                         );
+                    }
+                    if (this.ending_bot) {
                         ignore_promise(
-                            this.ending_bot?.sendMove(
+                            this.ending_bot.sendMove(
                                 decodeMoves(move.move, this.state.width, this.state.height)[0],
                                 this.state.width,
                                 this.state.height,
-                                this.my_color === "black" ? "white" : "black",
+                                "black",
                             ),
                         );
                     }
@@ -301,6 +303,7 @@ export class Game extends EventEmitter<Events> {
                     }
                 }
             } else {
+                const opponent_color = this.my_color === "black" ? "white" : "black";
                 if (move.move_number % 2 === this.opponent_evenodd) {
                     // We just got a move from the opponent, so we can move immediately.
                     //
@@ -310,15 +313,17 @@ export class Game extends EventEmitter<Events> {
                                 decodeMoves(move.move, this.state.width, this.state.height)[0],
                                 this.state.width,
                                 this.state.height,
-                                this.my_color === "black" ? "white" : "black",
+                                opponent_color,
                             ),
                         );
+                    }
+                    if (this.ending_bot) {
                         ignore_promise(
-                            this.ending_bot?.sendMove(
+                            this.ending_bot.sendMove(
                                 decodeMoves(move.move, this.state.width, this.state.height)[0],
                                 this.state.width,
                                 this.state.height,
-                                this.my_color === "black" ? "white" : "black",
+                                opponent_color,
                             ),
                         );
                     }


### PR DESCRIPTION
when `ending_bot` is `undefined`, `this.ending_bot?.sendMove(...)` evaluates to `undefined`. this means we are calling `ignore_promise(undefined)`, which is how we get

```
Aug 15 09:25:08 ! source-map-support.js:445 /snapshot/bench/gtp2ogs/dist/webpack:/gtp2ogs/src/util.ts:110
    promise.catch((e) => {
            ^
Aug 15 09:25:08 ! source-map-support.js:448 TypeError: Cannot read properties of undefined (reading 'catch')
    at ignore_promise (/snapshot/bench/gtp2ogs/dist/webpack:/gtp2ogs/src/util.ts:110:13)
    at GobanSocket.on_move (/snapshot/bench/gtp2ogs/dist/webpack:/gtp2ogs/src/Game.ts:316:39)
    at GobanSocket.emit (/snapshot/bench/gtp2ogs/node_modules/eventemitter3/index.js:181:35)
```

closes #410