### PR TITLE
A few tweaks to pause handling

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -24,6 +24,7 @@ export class Game extends EventEmitter<Events> {
 
     game_id: number;
     state: GobanEngineConfig;
+    paused: boolean = false;
     opponent_evenodd: null | number;
     greeted: boolean;
     player_chat_cutoff: number;
@@ -650,6 +651,10 @@ export class Game extends EventEmitter<Events> {
         if (this.state.phase !== "play") {
             return;
         }
+        if (this.paused) {
+            this.sendChat("Move made, unpausing clock");
+            this.resumeGame();
+        }
         if (!this.greeted && this.state.moves.length < 2 + this.state.handicap) {
             this.greeted = true;
             if (config.greeting?.en) {
@@ -854,6 +859,7 @@ export class Game extends EventEmitter<Events> {
         if (!clock.pause) {
             return;
         }
+        this.paused = clock.pause.paused;
 
         if (this.unpause_timeout) {
             clearTimeout(this.unpause_timeout);

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -846,13 +846,18 @@ export class Game extends EventEmitter<Events> {
     private checkForPause(): void {
         const clock = this.state?.clock;
 
+        if (!clock) {
+            return;
+        }
+
+        // clock.pause is only set when the pause state changes.
+        if (!clock.pause) {
+            return;
+        }
+
         if (this.unpause_timeout) {
             clearTimeout(this.unpause_timeout);
             this.unpause_timeout = undefined;
-        }
-
-        if (!clock) {
-            return;
         }
 
         if (clock.pause?.paused && clock.paused_since) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -275,7 +275,7 @@ class Main {
 
     countGames(speed: Speed) {
         return Object.values(this.connected_games).filter(
-            (g) => g?.state?.time_control?.speed === speed,
+            (g) => g?.state?.time_control?.speed === speed && !g?.paused,
         ).length;
     }
 


### PR DESCRIPTION
The first change fixes a bug where the unpause timeout does not trigger.

The second change is to not let players start a "blitz" game but then pause the game and play the entire game paused. I don't think there's any good reason for a user to do that and it can only confuse any stats/limits/logic that might assume that fast games actually are fast.

Third one follows right on forcing fast games to actually be fast - don't include paused games in ongoing game limits on the assumption that the pauses are actually used to walk away from the game so no resources will be used meanwhile.