### PR TITLE
default enable_clock to true

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -499,6 +499,7 @@ function bot_config_defaults(): Partial<BotConfig> {
     const base: Partial<BotConfig> = {
         manager: "persistent",
         instances: 1,
+        enable_clock: true,
         send_chats: true,
         send_pv_data: true,
         release_delay: 100,


### PR DESCRIPTION
The documentation says that enable_clock is true by default everywhere, but 212e894b neglected to actually set the default when it was renamed from disable_clock to enable_clock. So set it to true by default to match the documenation (and for a reasonable default).